### PR TITLE
Update intl_zh_CN.arb

### DIFF
--- a/lib/l10n/arb/intl_zh_CN.arb
+++ b/lib/l10n/arb/intl_zh_CN.arb
@@ -238,9 +238,9 @@
   "clipboardImport": "剪贴板导入",
   "clipboardExport": "导出剪贴板",
   "layout": "布局",
-  "tight": "宽松",
+  "tight": "紧凑",
   "standard": "标准",
-  "loose": "紧凑",
+  "loose": "宽松",
   "profilesSort": "配置排序",
   "start": "启动",
   "stop": "暂停"


### PR DESCRIPTION
fix: wrong translation of `tight` and `loose`