### PR TITLE
Optional name added when importing a profile from a URL

### DIFF
--- a/lib/common/string.dart
+++ b/lib/common/string.dart
@@ -8,4 +8,35 @@ extension StringExtension on String {
       other.toLowerCase(),
     );
   }
+
+  bool isValidFileName() {
+    if (trim().isEmpty) {
+      return false;
+    }
+
+    if (length > 255) {
+      return false;
+    }
+
+    final invalidChars = RegExp(r'[<>:"/\\|?*\x00-\x1F]');
+    if (invalidChars.hasMatch(this)) {
+      return false;
+    }
+
+    if (startsWith('.') || endsWith('.')) {
+      return false;
+    }
+
+    // Windows reserved names
+    final reservedNames = [
+      'CON', 'PRN', 'AUX', 'NUL',
+      'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
+      'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'
+    ];
+    if (reservedNames.contains(toUpperCase())) {
+      return false;
+    }
+
+    return true;
+  }
 }

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -381,16 +381,21 @@ class AppController {
     globalState.showSnackBar(context, message: message);
   }
 
-  addProfileFormURL(String url) async {
+  addProfileFormURL(String url, {String? label}) async {
     if (globalState.navigatorKey.currentState?.canPop() ?? false) {
       globalState.navigatorKey.currentState?.popUntil((route) => route.isFirst);
     }
+    if (label != null) {
+      label = label.isValidFileName() ? label : null;
+    }
+
     toProfiles();
     final commonScaffoldState = globalState.homeScaffoldKey.currentState;
     if (commonScaffoldState?.mounted != true) return;
     final profile = await commonScaffoldState?.loadingRun<Profile>(
       () async {
         return await Profile.normal(
+          label: label,
           url: url,
         ).update();
       },

--- a/lib/fragments/profiles/add_profile.dart
+++ b/lib/fragments/profiles/add_profile.dart
@@ -13,8 +13,8 @@ class AddProfile extends StatelessWidget {
     globalState.appController.addProfileFormFile();
   }
 
-  _handleAddProfileFormURL(String url) async {
-    globalState.appController.addProfileFormURL(url);
+  _handleAddProfileFormURL(String url, {String? label}) async {
+    globalState.appController.addProfileFormURL(url, label: label);
   }
 
   _toScan() async {
@@ -32,11 +32,16 @@ class AddProfile extends StatelessWidget {
   }
 
   _toAdd() async {
-    final url = await globalState.showCommonDialog<String>(
+    // final url = await globalState.showCommonDialog<String>(
+    //   child: const URLFormDialog(),
+    // );
+    final urlAndName = await globalState.showCommonDialog<Map<String, String>>(
       child: const URLFormDialog(),
     );
+    final url = urlAndName?['url'];
+    final name = urlAndName?['name'];
     if (url != null) {
-      _handleAddProfileFormURL(url);
+      _handleAddProfileFormURL(url, label: name);
     }
   }
 
@@ -74,14 +79,21 @@ class URLFormDialog extends StatefulWidget {
   State<URLFormDialog> createState() => _URLFormDialogState();
 }
 
+
 class _URLFormDialogState extends State<URLFormDialog> {
   final urlController = TextEditingController();
+  final nameController = TextEditingController();
 
   _handleAddProfileFormURL() async {
     final url = urlController.value.text;
+    final name = nameController.value.text;
     if (url.isEmpty) return;
-    Navigator.of(context).pop<String>(url);
+    Navigator.of(context).pop<Map<String, String>>({
+      'url': url,
+      'name': name,
+    });
   }
+
 
   @override
   Widget build(BuildContext context) {
@@ -99,6 +111,15 @@ class _URLFormDialogState extends State<URLFormDialog> {
               decoration: InputDecoration(
                 border: const OutlineInputBorder(),
                 labelText: appLocalizations.url,
+              ),
+            ),
+            TextField(
+              maxLines: 1,
+              minLines: 1,
+              controller: nameController,
+              decoration: InputDecoration(
+                border: const OutlineInputBorder(),
+                labelText: appLocalizations.urlName,
               ),
             ),
           ],

--- a/lib/l10n/intl/messages_en.dart
+++ b/lib/l10n/intl/messages_en.dart
@@ -419,6 +419,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "url": MessageLookupByLibrary.simpleMessage("URL"),
         "urlDesc":
             MessageLookupByLibrary.simpleMessage("Obtain profile through URL"),
+        "urlName": MessageLookupByLibrary.simpleMessage("Name(optional)"),
         "useHosts": MessageLookupByLibrary.simpleMessage("Use hosts"),
         "useSystemHosts":
             MessageLookupByLibrary.simpleMessage("Use system hosts"),

--- a/lib/l10n/intl/messages_zh_CN.dart
+++ b/lib/l10n/intl/messages_zh_CN.dart
@@ -335,6 +335,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "upload": MessageLookupByLibrary.simpleMessage("上传"),
         "url": MessageLookupByLibrary.simpleMessage("URL"),
         "urlDesc": MessageLookupByLibrary.simpleMessage("通过URL获取配置文件"),
+        "urlName": MessageLookupByLibrary.simpleMessage("配置名称（可选）"),
         "useHosts": MessageLookupByLibrary.simpleMessage("使用Hosts"),
         "useSystemHosts": MessageLookupByLibrary.simpleMessage("使用系统Hosts"),
         "value": MessageLookupByLibrary.simpleMessage("值"),

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -780,6 +780,16 @@ class AppLocalizations {
     );
   }
 
+  /// `Profile Name(optional)`
+  String get urlName {
+    return Intl.message(
+      'Profile Name(optional)',
+      name: 'urlName',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Obtain profile through URL`
   String get urlDesc {
     return Intl.message(


### PR DESCRIPTION
当从远程地址导入配置时，在弹出的输入页面添加一个文本输入框，用来指定这个配置的名字。这样如果有重命名需求时就不用导入之后再点开配置编辑名称了。