### PR TITLE
Remove redundant ".\" from dart commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Support the following actions
         3. Run Build script
 
            ```bash
-           dart .\setup.dart android
+           dart setup.dart android
            ```
 
     - windows
@@ -93,7 +93,7 @@ Support the following actions
         3. Run build script
 
            ```bash
-           dart .\setup.dart windows --arch <arm64 | amd64>
+           dart setup.dart windows --arch <arm64 | amd64>
            ```
 
     - linux
@@ -103,7 +103,7 @@ Support the following actions
         2. Run build script
 
            ```bash
-           dart .\setup.dart linux --arch <arm64 | amd64>
+           dart setup.dart linux --arch <arm64 | amd64>
            ```
 
     - macOS
@@ -113,7 +113,7 @@ Support the following actions
         2. Run build script
 
            ```bash
-           dart .\setup.dart macos --arch <arm64 | amd64>
+           dart setup.dart macos --arch <arm64 | amd64>
            ```
 
 ## Star

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -81,7 +81,7 @@ on Mobile:
         3. 运行构建脚本
 
            ```bash
-           dart .\setup.dart android
+           dart setup.dart android
            ```
 
     - windows
@@ -93,7 +93,7 @@ on Mobile:
         3. 运行构建脚本
 
            ```bash
-           dart .\setup.dart windows --arch <arm64 | amd64>
+           dart setup.dart windows --arch <arm64 | amd64>
            ```
 
     - linux
@@ -103,7 +103,7 @@ on Mobile:
         2. 运行构建脚本
 
            ```bash
-           dart .\setup.dart linux --arch <arm64 | amd64>
+           dart setup.dart linux --arch <arm64 | amd64>
            ```
 
     - macOS
@@ -113,7 +113,7 @@ on Mobile:
         2. 运行构建脚本
 
            ```bash
-           dart .\setup.dart macos --arch <arm64 | amd64>
+           dart setup.dart macos --arch <arm64 | amd64>
            ```
 
 ## Star History


### PR DESCRIPTION
Removed the redundant ".\" prefix from all dart setup.dart commands in README.md to improve command consistency across platforms.

反斜杠只有windows能用， 实际上这里不需要点开头，直接dart setup.dart就可以跨平台使用，