### PR TITLE
Fix GNOME ignore-hosts cmd

### DIFF
--- a/lib/common/tray.dart
+++ b/lib/common/tray.dart
@@ -81,6 +81,7 @@ class Tray {
     }
     menuItems.add(MenuItem.separator());
     if (!Platform.isWindows) {
+      List<MenuItem> groupMenuItems = [];
       for (final group in trayState.groups) {
         List<MenuItem> subMenuItems = [];
         for (final proxy in group.all) {
@@ -102,7 +103,7 @@ class Tray {
             ),
           );
         }
-        menuItems.add(
+        groupMenuItems.add(
           MenuItem.submenu(
             label: group.name,
             submenu: Menu(
@@ -111,6 +112,14 @@ class Tray {
           ),
         );
       }
+      menuItems.add(
+        MenuItem.submenu(
+          label: appLocalizations.proxies,
+          submenu: Menu(
+            items: groupMenuItems,
+          ),
+        ),
+      );
       if (trayState.groups.isNotEmpty) {
         menuItems.add(MenuItem.separator());
       }

--- a/plugins/proxy/lib/proxy.dart
+++ b/plugins/proxy/lib/proxy.dart
@@ -68,7 +68,7 @@ class Proxy extends ProxyPlatform {
         cmdList.add(
           ["gsettings", "set", "org.gnome.system.proxy", "mode", "manual"],
         );
-        final ignoreHosts = "\"['${bypassDomain.join("', '")}']\"";
+        final ignoreHosts = "['${bypassDomain.join("', '")}']";
         cmdList.add(
           [
             "gsettings",


### PR DESCRIPTION
The extra quotes are redundant and lead to errors. Without this fix, the bypass rules do not work on GNOME desktops.