### PR TITLE
Fix GNOME ignore-hosts cmd

### DIFF
--- a/plugins/proxy/lib/proxy.dart
+++ b/plugins/proxy/lib/proxy.dart
@@ -68,7 +68,7 @@ class Proxy extends ProxyPlatform {
         cmdList.add(
           ["gsettings", "set", "org.gnome.system.proxy", "mode", "manual"],
         );
-        final ignoreHosts = "\"['${bypassDomain.join("', '")}']\"";
+        final ignoreHosts = "['${bypassDomain.join("', '")}']";
         cmdList.add(
           [
             "gsettings",


### PR DESCRIPTION
The extra quotes are redundant and lead to errors. Without this fix, the bypass rules do not work on GNOME desktops.