### PR TITLE
Hide proxy groups in tray submenu

### DIFF
--- a/lib/common/tray.dart
+++ b/lib/common/tray.dart
@@ -81,6 +81,7 @@ class Tray {
     }
     menuItems.add(MenuItem.separator());
     if (!Platform.isWindows) {
+      List<MenuItem> groupMenuItems = [];
       for (final group in trayState.groups) {
         List<MenuItem> subMenuItems = [];
         for (final proxy in group.all) {
@@ -102,7 +103,7 @@ class Tray {
             ),
           );
         }
-        menuItems.add(
+        groupMenuItems.add(
           MenuItem.submenu(
             label: group.name,
             submenu: Menu(
@@ -111,6 +112,14 @@ class Tray {
           ),
         );
       }
+      menuItems.add(
+        MenuItem.submenu(
+          label: appLocalizations.proxies,
+          submenu: Menu(
+            items: groupMenuItems,
+          ),
+        ),
+      );
       if (trayState.groups.isNotEmpty) {
         menuItems.add(MenuItem.separator());
       }


### PR DESCRIPTION
On a GNOME desktop, an excessive number of proxy groups can cause tray menu to overflow the screen, which makes some menu items (such as "Quit") inaccessible. I believe that this issue stems from `tray_manager` or even `libayatana-appindicator`. Before the upstreams fix this issue, I propose to hide the proxy groups in a submenu as a workaround.