### PR TITLE
Build Linux app in the oldest Ubuntu for better compatibility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
             os: windows-latest
             arch: amd64
           - platform: linux
-            os: ubuntu-latest
+            os: ubuntu-22.04
             arch: amd64
           - platform: macos
             os: macos-13


### PR DESCRIPTION
The current Linux CI builds can't run on older but still-supported distros (for me, that's Debian 12 [^1]). 

- The latest Ubuntu (24.04) CI produces "GLIBC_2.38" binary, while I'm using 2.36. [^2]
- GTK API "g_once_init_enter_pointer" is introduced in GLIB 2.80, while I have only 2.74.6. [^3][^4]

Switching to Ubuntu 22.04 will solve this problem because Ubuntu 22.04 has "GLIBC_2.35" and GLIB 2.72.4. [^5]

[^1]: https://wiki.debian.org/LTS
[^2]: "libc6 (>= 2.38)" in https://packages.ubuntu.com/noble/libstdc++6
[^3]: "libglib2.0-0 (2.74.6..." in https://packages.debian.org/bookworm/libglib2.0-0
[^4]: "Available since: 2.80" in https://docs.gtk.org/glib/type_func.Once.init_enter_pointer.html
[^5]: https://packages.ubuntu.com/jammy/libc6; https://packages.ubuntu.com/jammy/libglib2.0-0

Ref:

- libglib:
    - https://github.com/flutter/flutter/issues/145405
    - https://github.com/cirruslabs/docker-images-flutter/issues/337
    - https://github.com/bambulab/BambuStudio/issues/4956
- GitHub Actions:
    - https://github.com/actions/runner-images/issues/11101

.