### PR TITLE
Add dependency info to DEB and RPM packages; improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,19 @@ on Mobile:
 
 ### Linux
 
-⚠️ Make sure to install the following dependencies before using them
+⚠️ Make sure to install the following dependencies before use
 
    ```bash
-    sudo apt-get install libayatana-appindicator3-1 libayatana-appindicator3-dev
+    # Debian/Ubuntu
+    sudo apt-get install libayatana-appindicator3-1
     sudo apt-get install libkeybinder-3.0-0
+
+    # Fedora/CentOS
+    sudo dnf install libayatana-appindicator-gtk3
+    sudo dnf install keybinder3
    ```
+
+In GNOME desktop environment, the [AppIndicator](https://github.com/ubuntu/gnome-shell-extension-appindicator) extension may be required to display systray icon
 
 ### Android
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ on Mobile:
 ⚠️ Make sure to install the following dependencies before using them
 
    ```bash
-    sudo apt-get install appindicator3-0.1 libappindicator3-dev
-    sudo apt-get install keybinder-3.0
+    sudo apt-get install libayatana-appindicator3-1 libayatana-appindicator3-dev
+    sudo apt-get install libkeybinder-3.0-0
    ```
 
 ### Android

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -41,9 +41,16 @@ on Mobile:
 ⚠️ 使用前请确保安装以下依赖
 
    ```bash
-    sudo apt-get install libayatana-appindicator3-1 libayatana-appindicator3-dev
+    # Debian/Ubuntu
+    sudo apt-get install libayatana-appindicator3-1
     sudo apt-get install libkeybinder-3.0-0
+
+    # Fedora/CentOS
+    sudo dnf install libayatana-appindicator-gtk3
+    sudo dnf install keybinder3
    ```
+
+在使用 GNOME 桌面时, 可能需要安装 [AppIndicator](https://github.com/ubuntu/gnome-shell-extension-appindicator) 扩展以显示系统托盘图标
 
 ### Android
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -41,8 +41,8 @@ on Mobile:
 ⚠️ 使用前请确保安装以下依赖
 
    ```bash
-    sudo apt-get install appindicator3-0.1 libappindicator3-dev
-    sudo apt-get install keybinder-3.0
+    sudo apt-get install libayatana-appindicator3-1 libayatana-appindicator3-dev
+    sudo apt-get install libkeybinder-3.0-0
    ```
 
 ### Android

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -23,3 +23,7 @@ categories:
   - Network
 
 startup_notify: true
+
+dependencies:
+  - libayatana-appindicator3-1
+  - libkeybinder-3.0-0

--- a/linux/packaging/rpm/make_config.yaml
+++ b/linux/packaging/rpm/make_config.yaml
@@ -21,3 +21,7 @@ generic_name: FlClash
 group: Applications/Internet
 
 startup_notify: true
+
+requires:
+  - keybinder3
+  - libayatana-appindicator-gtk3


### PR DESCRIPTION
Inspired by @YSXX1013's work (#1089). Please squash all commits before merge.

Test:

| DEB | RPM |
|:-:|:-:|
| In GNOME on Debian 12 (needs #1102 to be applied) | In KDE on Fedora 40 |
| ![FlClash-DEB-package-on-Debian-12-GNOME](https://github.com/user-attachments/assets/a0d6faca-ae30-446e-843f-545f9ab35814) | ![FlClash-RPM-package-on-Fedora-40-KDE](https://github.com/user-attachments/assets/24599622-b89a-4251-9b56-b3d59f698b66) |

Ref: 恢复 GNOME 顶栏的托盘图标 | Linux 中国 https://linux.cn/article-13785-1.html, https://linux.net.cn/article-13785-1.html, https://mp.weixin.qq.com/s/gqXATcAp7qDlrClL21iBXQ, https://zhuanlan.zhihu.com/p/410500061

.