### PR TITLE
Fix windows tray issues by upgrading tray_manager; remove useless code

### DIFF
--- a/lib/manager/window_manager.dart
+++ b/lib/manager/window_manager.dart
@@ -103,12 +103,6 @@ class _WindowContainerState extends ConsumerState<WindowManager>
   }
 
   @override
-  Future<void> onTaskbarCreated() async {
-    globalState.appController.updateTray(true);
-    super.onTaskbarCreated();
-  }
-
-  @override
   Future<void> dispose() async {
     windowManager.removeListener(this);
     windowExtManager.removeListener(this);

--- a/plugins/window_ext/lib/window_ext_listener.dart
+++ b/plugins/window_ext/lib/window_ext_listener.dart
@@ -1,5 +1,3 @@
 abstract mixin class WindowExtListener {
-  void onTaskbarCreated() {}
-
   void onShouldTerminate() {}
 }

--- a/plugins/window_ext/lib/window_ext_manager.dart
+++ b/plugins/window_ext/lib/window_ext_manager.dart
@@ -18,9 +18,6 @@ class WindowExtManager {
   Future<void> _methodCallHandler(MethodCall call) async {
     for (final WindowExtListener listener in _listeners) {
       switch (call.method) {
-        case "taskbarCreated":
-          listener.onTaskbarCreated();
-          break;
         case "shouldTerminate":
           listener.onShouldTerminate();
           break;

--- a/plugins/window_ext/windows/window_ext_plugin.cpp
+++ b/plugins/window_ext/windows/window_ext_plugin.cpp
@@ -42,7 +42,6 @@ void WindowExtPlugin::RegisterWithRegistrar(
 
 WindowExtPlugin::WindowExtPlugin(flutter::PluginRegistrarWindows* registrar)
     : registrar(registrar) {
-  WM_TASKBARCREATED = RegisterWindowMessage(TEXT("TaskbarCreated"));
   window_proc_id = registrar->RegisterTopLevelWindowProcDelegate(
       [this](HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) {
         return HandleWindowProc(hwnd, message, wparam, lparam);
@@ -58,9 +57,6 @@ std::optional<LRESULT> WindowExtPlugin::HandleWindowProc(HWND hWnd,
                                                            WPARAM wParam,
                                                            LPARAM lParam) {
   std::optional<LRESULT> result;
-  if(message == WM_TASKBARCREATED){
-    channel -> InvokeMethod("taskbarCreated", std::make_unique<flutter::EncodableValue>());
-  }
   return result;
 }
 

--- a/plugins/window_ext/windows/window_ext_plugin.h
+++ b/plugins/window_ext/windows/window_ext_plugin.h
@@ -32,7 +32,6 @@ class WindowExtPlugin : public flutter::Plugin {
               LPARAM lparam);
 
   int window_proc_id = -1;
-  UINT WM_TASKBARCREATED = 0;
   flutter::PluginRegistrarWindows *registrar;
 };
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1378,10 +1378,10 @@ packages:
     dependency: "direct main"
     description:
       name: tray_manager
-      sha256: c2da0f0f1ddb455e721cf68d05d1281fec75cf5df0a1d3cb67b6ca0bdfd5709d
+      sha256: ad18c4cd73003097d182884bacb0578ad2865f3ab842a0ad00f6d043ed49eaf0
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.5.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   mobile_scanner: ^6.0.2
   app_links: ^6.4.0
   win32_registry: ^2.0.0
-  tray_manager: ^0.4.0
+  tray_manager: ^0.5.0
   collection: ^1.18.0
   animations: ^2.0.11
   package_info_plus: ^8.0.0


### PR DESCRIPTION
We don't need to listen to "WM_TASKBARCREATED" any more. See what's new in tray_manager 0.5.0: https://github.com/leanflutter/tray_manager/releases/tag/v0.5.0

Related issues: 

- https://github.com/chen08209/FlClash/issues/409#issuecomment-2398885912

Test video:

<video src="https://github.com/user-attachments/assets/fed48ccb-c366-4a5e-a023-6431237455fd">
Video: "20250428-FlClash-taskbar-system-tray-fix-explorer-restart.mp4"
</video>

.