### PR TITLE
允许在运行期间使用广播切换运行模式

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -89,6 +89,16 @@
             </intent-filter>
         </activity>
 
+        <receiver
+            android:name=".ChangeModeReceiver"
+            android:enabled="true"
+            android:exported="true"
+            tools:ignore="ExportedReceiver">
+            <intent-filter>
+                <action android:name="${applicationId}.action.CHANGE_MODE" />
+            </intent-filter>
+        </receiver>
+
         <service
             android:name=".services.FlClashTileService"
             android:exported="true"

--- a/android/app/src/main/java/com/follow/clash/ChangeModeReceiver.kt
+++ b/android/app/src/main/java/com/follow/clash/ChangeModeReceiver.kt
@@ -1,0 +1,20 @@
+package com.follow.clash
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.follow.clash.extensions.wrapAction
+
+class ChangeModeReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val appContext = FlClashApplication.getAppContext()
+        when (intent.action) {
+            appContext.wrapAction("CHANGE_MODE") -> {
+                val mode = intent.getStringExtra("mode")
+                if (mode != null) {
+                    GlobalState.handleChangeMode(mode)
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/follow/clash/GlobalState.kt
+++ b/android/app/src/main/kotlin/com/follow/clash/GlobalState.kt
@@ -89,6 +89,10 @@ object GlobalState {
         }
     }
 
+    fun handleChangeMode(modeKey: String) {
+        getCurrentAppPlugin()?.changeMode(modeKey)
+    }
+
     fun handleTryDestroy() {
         if (flutterEngine == null) {
             destroyServiceEngine()

--- a/android/app/src/main/kotlin/com/follow/clash/plugins/AppPlugin.kt
+++ b/android/app/src/main/kotlin/com/follow/clash/plugins/AppPlugin.kt
@@ -427,6 +427,10 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
         return false
     }
 
+    fun changeMode(modeKey: String) {
+        channel.invokeMethod("changeMode", modeKey)
+    }
+
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activityRef = WeakReference(binding.activity)
         binding.addActivityResultListener(::onActivityResult)

--- a/lib/enum/enum.dart
+++ b/lib/enum/enum.dart
@@ -87,7 +87,20 @@ extension UsedProxyExtension on UsedProxy {
   String get value => UsedProxyExtension.valueList[index];
 }
 
-enum Mode { rule, global, direct }
+enum Mode {
+  rule,
+  global,
+  direct;
+
+  static Mode fromString(String mode) {
+    return switch (mode) {
+      "rule" => Mode.rule,
+      "global" => Mode.global,
+      "direct" => Mode.direct,
+      String() => throw UnimplementedError(),
+    };
+  }
+}
 
 enum ViewMode { mobile, laptop, desktop }
 

--- a/lib/plugins/app.dart
+++ b/lib/plugins/app.dart
@@ -4,7 +4,10 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:fl_clash/common/app_localizations.dart';
+import 'package:fl_clash/common/print.dart';
+import 'package:fl_clash/enum/enum.dart';
 import 'package:fl_clash/models/models.dart';
+import 'package:fl_clash/state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
@@ -28,6 +31,14 @@ class App {
           } catch (_) {
             return "";
           }
+        case "changeMode":
+          if (call.arguments is String) {
+            commonPrint.log("change mode to ${call.arguments}");
+            globalState.appController
+                .changeMode(Mode.fromString(call.arguments as String));
+            await globalState.appController.savePreferences();
+          }
+          break;
         default:
           throw MissingPluginException();
       }


### PR DESCRIPTION
Partial fix for #1208 and #1118.

允许外部的 App 使用 Broadcast Intent 的方式对出站模式进行切换，方便使用 Tasker 等工具实现基于 WiFi SSID 或者其他条件的自动化。直接使用 Start/Stop 开关服务由于需要启动 Activity 才能触发，在熄屏时不稳定，且可能干扰前台用户的正常操作，本 PR 的通信方式完全在后台进行。