### PR TITLE
Add Ubuntu 20.04 to build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,9 @@ jobs:
           - platform: linux
             os: ubuntu-22.04
             arch: amd64
+          - platform: linux
+            os: ubuntu-20.04
+            arch: amd64
           - platform: macos
             os: macos-13
             arch: amd64


### PR DESCRIPTION

增加了ubuntu20.4版本编译
参考 https://github.com/chen08209/FlClash/issues/1133
（ps：真的只要加个ubuntu20.4就行？那我就直接pr了）