### PR TITLE
Enable process mode by default & improve profile label handling

### DIFF
--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -674,41 +674,53 @@ class AppController {
     return;
   }
 
+  
   String _getLabelFromURL(String url, {int maxLength = 50}) {
     String label;
     try {
       final uri = Uri.parse(url);
-  
+
       // Case 1: if URL has query parameters with 'url'
       if (uri.queryParameters.containsKey('url')) {
         return _getLabelFromURL(uri.queryParameters['url']!, maxLength: maxLength);
       }
-  
-      // Case 2: normal URL → use last segment
-      final segments = uri.pathSegments;
-      if (segments.isNotEmpty) {
-        final fileName = segments.last;
-        label = fileName.contains('.') 
-            ? fileName.split('.').first 
-            : fileName;
+
+      final isShortLink = (uri.host.split('.').length <= 2 && uri.pathSegments.length <= 2) || url.length < 30;
+
+      if (uri.host.contains("githubusercontent.com") && uri.pathSegments.length > 1) {
+        // GitHub raw links → use repo owner + last filename
+        final owner = uri.pathSegments[0];
+        final file = uri.pathSegments.last;
+        label = "$owner-${file.split('.').first}";
+      } else if (isShortLink) {
+        // Short link → host + code
+        label = "${uri.host}-${uri.pathSegments.join('-')}";
       } else {
-        label = url;
+        // Default: host + last path segment (without extension)
+        if (uri.pathSegments.isNotEmpty) {
+          final fileName = uri.pathSegments.last;
+          label = "${uri.host}-${fileName.split('.').first}";
+        } else {
+          label = uri.host;
+        }
       }
     } catch (_) {
-      // Case 3: fallback for short/opaque URLs → convert host+path into readable name
+      // Case 3: fallback for opaque/invalid URLs
       label = url
-          .replaceAll(RegExp(r'https?://'), '')  // remove protocol
-          .replaceAll(RegExp(r'[/\?&=]'), '-')  // replace special chars
-          .replaceAll(RegExp(r'[^0-9a-zA-Z\-_]'), ''); // remove unsafe chars
+          .replaceAll(RegExp(r'https?://'), '') // remove protocol
+          .replaceAll(RegExp(r'[/\?&=]'), '-')  // replace separators
+          .replaceAll(RegExp(r'[^0-9a-zA-Z\-_]'), ''); // strip unsafe chars
+          .replaceAll(RegExp(r'-+'), '-'); // collapse repeated dashes
     }
   
-    // Truncate if longer than maxLength
+    // Truncate
     if (label.length > maxLength) {
       label = label.substring(0, maxLength);
     }
   
-    return label.isNotEmpty ? label : utils.id;
+    return label.isNotEmpty ? label : '';
   }
+
   
   Future<void> addProfileFormURL(String url) async {
     if (globalState.navigatorKey.currentState?.canPop() ?? false) {

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -674,6 +674,22 @@ class AppController {
     return;
   }
 
+  String _getLabelFromURL(String url) {
+    try {
+      final uri = Uri.parse(url);
+      final segments = uri.pathSegments;
+      if (segments.isNotEmpty) {
+        final fileName = segments.last;
+        // remove extension if any
+        final nameWithoutExt = fileName.contains('.') 
+            ? fileName.split('.').first 
+            : fileName;
+        return nameWithoutExt;
+      }
+    } catch (_) {}
+    return utils.id; // fallback
+  }
+  
   Future<void> addProfileFormURL(String url) async {
     if (globalState.navigatorKey.currentState?.canPop() ?? false) {
       globalState.navigatorKey.currentState?.popUntil((route) => route.isFirst);
@@ -684,6 +700,7 @@ class AppController {
       () async {
         return await Profile.normal(
           url: url,
+          label: _getLabelFromURL(url),  // new label from URL
         ).update();
       },
       needLoading: true,

--- a/lib/models/clash_config.dart
+++ b/lib/models/clash_config.dart
@@ -484,7 +484,7 @@ class ClashConfig with _$ClashConfig {
     @Default(false) @JsonKey(name: 'allow-lan') bool allowLan,
     @Default(LogLevel.error) @JsonKey(name: 'log-level') LogLevel logLevel,
     @Default(false) bool ipv6,
-    @Default(FindProcessMode.off)
+    @Default(FindProcessMode.always)
     @JsonKey(
       name: 'find-process-mode',
       unknownEnumValue: FindProcessMode.always,

--- a/lib/models/generated/clash_config.freezed.dart
+++ b/lib/models/generated/clash_config.freezed.dart
@@ -3924,7 +3924,7 @@ class _$ClashConfigImpl implements _ClashConfig {
       this.ipv6 = false,
       @JsonKey(
           name: 'find-process-mode', unknownEnumValue: FindProcessMode.always)
-      this.findProcessMode = FindProcessMode.off,
+      this.findProcessMode = FindProcessMode.always,
       @JsonKey(name: 'keep-alive-interval')
       this.keepAliveInterval = defaultKeepAliveInterval,
       @JsonKey(name: 'unified-delay') this.unifiedDelay = true,

--- a/lib/models/generated/clash_config.g.dart
+++ b/lib/models/generated/clash_config.g.dart
@@ -345,7 +345,7 @@ _$ClashConfigImpl _$$ClashConfigImplFromJson(Map<String, dynamic> json) =>
       findProcessMode: $enumDecodeNullable(
               _$FindProcessModeEnumMap, json['find-process-mode'],
               unknownValue: FindProcessMode.always) ??
-          FindProcessMode.off,
+          FindProcessMode.always,
       keepAliveInterval: (json['keep-alive-interval'] as num?)?.toInt() ??
           defaultKeepAliveInterval,
       unifiedDelay: json['unified-delay'] as bool? ?? true,


### PR DESCRIPTION
**Summary**
1. **Process Mode Default**
   * Previously, `FindProcessMode` defaulted to `off`.
   * Many community rulesets require process mode, causing mismatches when left disabled.
   * This PR changes the default to `on` for better out-of-the-box compatibility.
2. **Profile Label from URL**
   * Profiles added from a URL would previously show a numeric ID because `label` was null.
   * This PR sets the profile label from the file name in the URL path, so the UI shows a meaningful name instead of just the ID.

**Changes**
* Set `@Default(FindProcessMode.off)` → `@Default(FindProcessMode.always)`.
* Updated `addProfileFormURL` to extract the filename from the URL and assign it as the profile label.
* Updated UI to display `profile.label` instead of `profile.id`.

**Impact**
* **Process Mode:** Rulesets depending on process mode now work out-of-the-box.
* **Profiles:** Imported profiles from URLs display human-readable names instead of numeric IDs.
* No breaking changes for existing explicit configs.

