### PR TITLE
Update flutter_js to 0.8.5

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -481,12 +481,11 @@ packages:
   flutter_js:
     dependency: "direct main"
     description:
-      path: "."
-      ref: master
-      resolved-ref: c0e10a5dab0e22cd616ec92ae71471d76369cbfe
-      url: "https://github.com/chen08209/flutter_js"
-    source: git
-    version: "0.8.3"
+      name: flutter_js
+      sha256: a04966b102967891ee4947d6e52b450676f16204876ba936e394008ca26db04b
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.5"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,10 +54,7 @@ dependencies:
   riverpod_annotation: ^3.0.0
   riverpod: ^3.0.0
   material_color_utilities: ^0.11.1
-  flutter_js:
-    git:
-      url: https://github.com/chen08209/flutter_js
-      ref: master
+  flutter_js: ^0.8.5
   flutter_svg: ^2.1.0
   flutter_cache_manager: ^3.4.1
   crypto: ^3.0.3


### PR DESCRIPTION
The current version of flutter_js fails to package libquickjs_c_bridge_plugin.so into the bundle. This issue is resolved by updating flutter_js to version 0.8.5.

#1318 
#1462