### PR TITLE
i18n: update English translation, add space after comma

### DIFF
--- a/arb/intl_en.arb
+++ b/arb/intl_en.arb
@@ -32,7 +32,7 @@
   "ru": "Russian",
   "zh_CN": "Simplified Chinese",
   "theme": "Theme",
-  "themeDesc": "Set dark mode,adjust the color",
+  "themeDesc": "Set dark mode, adjust the color",
   "override": "Override",
   "overrideDesc": "Override Proxy related config",
   "allowLan": "AllowLan",

--- a/arb/intl_en.arb
+++ b/arb/intl_en.arb
@@ -32,7 +32,7 @@
   "ru": "Russian",
   "zh_CN": "Simplified Chinese",
   "theme": "Theme",
-  "themeDesc": "Set dark mode, adjust the color",
+  "themeDesc": "Toggle dark mode and adjust colors",
   "override": "Override",
   "overrideDesc": "Override Proxy related config",
   "allowLan": "AllowLan",

--- a/lib/l10n/intl/messages_en.dart
+++ b/lib/l10n/intl/messages_en.dart
@@ -709,7 +709,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "theme": MessageLookupByLibrary.simpleMessage("Theme"),
     "themeColor": MessageLookupByLibrary.simpleMessage("Theme color"),
     "themeDesc": MessageLookupByLibrary.simpleMessage(
-      "Set dark mode,adjust the color",
+      "Toggle dark mode and adjust colors",
     ),
     "themeMode": MessageLookupByLibrary.simpleMessage("Theme mode"),
     "threeColumns": MessageLookupByLibrary.simpleMessage("Three columns"),

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -264,10 +264,10 @@ class AppLocalizations {
     return Intl.message('Theme', name: 'theme', desc: '', args: []);
   }
 
-  /// `Set dark mode,adjust the color`
+  /// `Toggle dark mode and adjust colors`
   String get themeDesc {
     return Intl.message(
-      'Set dark mode,adjust the color',
+      'Toggle dark mode and adjust colors',
       name: 'themeDesc',
       desc: '',
       args: [],


### PR DESCRIPTION
The previous translation "Set dark mode, adjust the color" was a direct, literal translation that sounded unnatural and slightly imperative in an English UI.

This commit updates the string to be more idiomatic and user-friendly by using more common terminology found in software interfaces.

- Old: `"Set dark mode,adjust the color"`
- New: `"Toggle dark mode and adjust colors"`