### PR TITLE
Fix: Resolve path compatibility issue for WebDAV cross-platform recovery

### DIFF
--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -902,7 +902,9 @@ class AppController {
       json.decode(utf8.decode(configFile.content)),
     );
     for (final profile in profiles) {
-      final filePath = join(homeDirPath, profile.name);
+      
+      final normalName = profile.name.replaceAll('\\', '/');
+      final filePath = join(homeDirPath, normalName);
       final file = File(filePath);
       await file.create(recursive: true);
       await file.writeAsBytes(profile.content);


### PR DESCRIPTION
This PR fixes #1504.

Resolves a cross-platform path issue during WebDAV recovery. Backups from Windows fail on Android because paths use '\' instead of '/'.

This PR normalizes paths in 'recoveryData' by replacing '\' with '/' before joining, which is compatible with all platforms.