### PR TITLE
Change submodule URLs to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "core/Clash.Meta"]
 	path = core/Clash.Meta
-	url = git@github.com:chen08209/Clash.Meta.git
+	url = https://github.com/chen08209/Clash.Meta
 	branch = FlClash
 [submodule "plugins/flutter_distributor"]
 	path = plugins/flutter_distributor
-	url = git@github.com:chen08209/flutter_distributor.git
+	url = https://github.com/chen08209/flutter_distributor
 	branch = FlClash
 
 


### PR DESCRIPTION
Fixes the errors like:

```
Cloning into '/Users/goooler/StudioProjects/FlClash/core/Clash.Meta'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:chen08209/Clash.Meta.git' into submodule path '/Users/goooler/StudioProjects/FlClash/core/Clash.Meta' failed
Failed to clone 'core/Clash.Meta'. Retry scheduled
Cloning into '/Users/goooler/StudioProjects/FlClash/plugins/flutter_distributor'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:chen08209/flutter_distributor.git' into submodule path '/Users/goooler/StudioProjects/FlClash/plugins/flutter_distributor' failed
Failed to clone 'plugins/flutter_distributor'. Retry scheduled
Cloning into '/Users/goooler/StudioProjects/FlClash/core/Clash.Meta'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:chen08209/Clash.Meta.git' into submodule path '/Users/goooler/StudioProjects/FlClash/core/Clash.Meta' failed
Failed to clone 'core/Clash.Meta' a second time, aborting
```