### PR TITLE
Enhance window management for Windows: track manual maximized state and restore bounds

### DIFF
--- a/lib/manager/window_manager.dart
+++ b/lib/manager/window_manager.dart
@@ -148,8 +148,8 @@ class WindowHeader extends StatefulWidget {
 class _WindowHeaderState extends State<WindowHeader> {
   final isMaximizedNotifier = ValueNotifier<bool>(false);
   final isPinNotifier = ValueNotifier<bool>(false);
-  bool _windowsBoundsMaximized =
-      false; // Track Windows-specific bounds-based maximize state
+  bool _manuallyMaximized =
+      false; // Track bounds-based manual maximize state
   Rect? _savedBounds; // Save window bounds before maximizing
   bool _isUpdatingMaximized =
       false; // Prevent concurrent maximize/unmaximize operations


### PR DESCRIPTION
Fix issue #1626
This pull request improves the window maximize and restore functionality, specifically for Windows platforms, by implementing manual maximize logic to better handle window sizing and restoration. The changes introduce state tracking for manual maximization and ensure the window restores to its previous size and position when unmaximized.

**Platform-specific window maximize behavior:**

* Added logic to manually maximize the window on Windows by saving the current window bounds and setting the window to the visible work area, excluding the taskbar. This ensures consistent maximize behavior on Windows.
* Implemented restoration of the saved window bounds when unmaximizing on Windows, so the window returns to its previous size and position.
* Introduced `_manualMaximized` and `_savedBounds` state variables to track manual maximization and saved window bounds.

**Dependency updates:**

* Added `screen_retriever` import to obtain display information needed for custom maximize logic.