### PR TITLE
Refactor back block handling in CommonScaffold to simplify dispose logic and improve readability

### DIFF
--- a/lib/widgets/pop_scope.dart
+++ b/lib/widgets/pop_scope.dart
@@ -62,10 +62,8 @@ class _SystemBackBlockState extends State<SystemBackBlock> {
 
   @override
   void dispose() {
+    globalState.appController.unBackBlock();
     super.dispose();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      globalState.appController.unBackBlock();
-    });
   }
 
   @override

--- a/lib/widgets/scaffold.dart
+++ b/lib/widgets/scaffold.dart
@@ -238,19 +238,22 @@ class CommonScaffoldState extends State<CommonScaffold> {
   Widget _buildAppBarWrap(Widget child) {
     final appBar = _isSearch ? _buildSearchingAppBarTheme(child) : child;
     if (_isEdit || _isSearch) {
-      return SystemBackBlock(
-        child: CommonPopScope(
-          onPop: (context) {
-            if (_isEdit || _isSearch) {
-              handleExitSearching();
-              _appBarState.value.editState?.onExit();
-              return false;
-            }
-            return true;
-          },
-          child: appBar,
-        ),
+      final wrappedAppBar = CommonPopScope(
+        onPop: (context) {
+          if (_isEdit || _isSearch) {
+            handleExitSearching();
+            _appBarState.value.editState?.onExit();
+            return false;
+          }
+          return true;
+        },
+        child: appBar,
       );
+      // Only block system back for edit mode, not search mode
+      if (_isEdit) {
+        return SystemBackBlock(child: wrappedAppBar);
+      }
+      return wrappedAppBar;
     }
     return appBar;
   }


### PR DESCRIPTION
Fix issue #1620 
This pull request refines how the system back button is handled in the app bar, especially distinguishing between edit and search modes. The main improvement ensures that the system back button is only blocked during edit mode, not search mode, leading to a more intuitive user experience.

Back button handling improvements:

* Updated `_buildAppBarWrap` in `CommonScaffoldState` so that `SystemBackBlock` is only applied during edit mode, allowing the system back button to function normally during search mode. (`lib/widgets/scaffold.dart`) [[1]](diffhunk://#diff-2804fa2a5ae6726cac5690433203db74702f6ee38877cb902a9d5095c419b578L241-R241) [[2]](diffhunk://#diff-2804fa2a5ae6726cac5690433203db74702f6ee38877cb902a9d5095c419b578L252-R256)
* Refactored the `dispose` method in `_SystemBackBlockState` to immediately call `unBackBlock` before `super.dispose()`, ensuring proper cleanup without unnecessary post-frame callbacks. (`lib/widgets/pop_scope.dart`)