### PR TITLE
Add Windows ARM64 build support via cross-compilation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,9 @@ jobs:
           - platform: windows
             os: Windows-2022
             arch: amd64
+          - platform: windows
+            os: Windows-2022
+            arch: arm64
           - platform: linux
             os: ubuntu-22.04
             arch: amd64
@@ -35,13 +38,17 @@ jobs:
             arch: arm64
 
     steps:
-      - name: Setup rust
-        if: startsWith(matrix.os, 'windows-11-arm')
-        run: |
-          Invoke-WebRequest -Uri "https://win.rustup.rs/aarch64" -OutFile rustup-init.exe
-          .\rustup-init.exe -y --default-toolchain stable
-          $cargoPath = "$env:USERPROFILE\.cargo\bin"
-          Add-Content $env:GITHUB_PATH $cargoPath
+#      - name: Setup rust
+#        if: startsWith(matrix.os, 'windows-11-arm')
+#        run: |
+#          Invoke-WebRequest -Uri "https://win.rustup.rs/aarch64" -OutFile rustup-init.exe
+#          .\rustup-init.exe -y --default-toolchain stable
+#          $cargoPath = "$env:USERPROFILE\.cargo\bin"
+#          Add-Content $env:GITHUB_PATH $cargoPath
+
+      - name: Setup Rust Target
+        if: matrix.platform == 'windows' && matrix.arch == 'arm64'
+        run: rustup target add aarch64-pc-windows-msvc
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Resolve #1498

**描述:**
本 PR 通过在标准的 `windows-2022` Runner 上使用交叉编译的方式，得以在 GitHub 提供的标准 x64 Runner 上构建 Windows ARM64 版本。恢复了 Windows ARM64 版本的构建支持。

主要变更包括：

1. 在构建矩阵 (matrix) 中添加了 `windows-2022` + `arm64` 的组合。
2. 针对该组合添加了 `Setup Rust Target` 步骤，安装 `aarch64-pc-windows-msvc` 工具链。
3. 注释掉了旧的、不再使用的 `windows-11-arm` Runner 相关配置。
