### PR TITLE
fix: 修复搜索模式下窗口关闭按钮失效的问题

### DIFF
--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -430,8 +430,8 @@ class AppController {
     addCheckIpNumDebounce();
   }
 
-  Future<void> handleBackOrExit() async {
-    if (_ref.read(backBlockProvider)) {
+  Future<void> handleBackOrExit({bool force = false}) async {
+    if (!force && _ref.read(backBlockProvider)) {
       return;
     }
     if (_ref.read(appSettingProvider).minimizeOnExit) {

--- a/lib/manager/window_manager.dart
+++ b/lib/manager/window_manager.dart
@@ -44,7 +44,7 @@ class _WindowContainerState extends ConsumerState<WindowManager>
 
   @override
   void onWindowClose() async {
-    await globalState.appController.handleBackOrExit();
+    await globalState.appController.handleBackOrExit(force: true);
     super.onWindowClose();
   }
 
@@ -222,7 +222,7 @@ class _WindowHeaderState extends State<WindowHeader> {
         ),
         IconButton(
           onPressed: () {
-            globalState.appController.handleBackOrExit();
+            globalState.appController.handleBackOrExit(force: true);
           },
           icon: const Icon(Icons.close),
         ),


### PR DESCRIPTION
## 关联 Issue

Fixes #1574

## 问题描述

在连接面板、代理面板、请求面板进行搜索后，如果不关闭搜索框，窗口的关闭按钮会失效。

## 原因分析

当进入搜索模式时，`SystemBackBlock` 会设置 `backBlock = true`，目的是防止用户通过系统返回键意外退出搜索/编辑模式。

但 `handleBackOrExit()` 函数会检查这个标志，导致**所有**关闭操作都被阻止，包括用户显式点击的关闭按钮。

## 修复方案

为 `handleBackOrExit()` 添加 `force` 参数：
- `force = false`（默认）：保持原有行为，系统返回键/快捷键会先退出搜索模式
- `force = true`：跳过 `backBlock` 检查，允许直接关闭窗口

窗口关闭按钮和系统窗口关闭事件使用 `force: true`，确保用户的显式关闭意图能被执行。

## 改动文件

- `lib/controller.dart`：添加 `force` 参数
- `lib/manager/window_manager.dart`：关闭按钮和 `onWindowClose` 事件使用 `force: true`

## 测试

已在 Windows 11 上测试通过：
- ✅ 搜索模式下点击关闭按钮可正常关闭
- ✅ 搜索模式下系统标题栏 X 按钮可正常关闭
- ✅ 快捷键 Ctrl+W 仍保持原有行为（先退出搜索）