### PR TITLE
replace devel depencencies in deb package

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,23 @@ on Mobile:
 ⚠️ Make sure to install the following dependencies before using them
 
    ```bash
-    sudo apt-get install libayatana-appindicator3-dev
-    sudo apt-get install libkeybinder-3.0-dev
+    sudo apt-get install libayatana-appindicator3-1
+    sudo apt-get install libkeybinder-3.0-0
    ```
+
+<details>
+
+<summary>about debian package</summary>
+
+this project used to be using devel libraries as dependencies, which is an overkill
+
+```bash
+sudo apt-get install libayatana-appindicator3-dev
+sudo apt-get install libkeybinder-3.0-dev
+```
+
+</details>
+
 
 ### Android
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -41,8 +41,8 @@ on Mobile:
 ⚠️ 使用前请确保安装以下依赖
 
    ```bash
-    sudo apt-get install libayatana-appindicator3-dev
-    sudo apt-get install libkeybinder-3.0-dev
+    sudo apt-get install libayatana-appindicator3-1
+    sudo apt-get install libkeybinder-3.0-0
    ```
 
 <details>

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -45,6 +45,19 @@ on Mobile:
     sudo apt-get install libkeybinder-3.0-dev
    ```
 
+<details>
+
+<summary>有关deb包依赖问题</summary>
+
+这个项目以前使用的是devel依赖，可以试着一起装上
+
+```bash
+sudo apt-get install libayatana-appindicator3-dev
+sudo apt-get install libkeybinder-3.0-dev
+```
+
+</details>
+
 ### Android
 
 支持下列操作

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -11,8 +11,8 @@ essential: false
 icon: ./assets/images/icon.png
 
 dependencies:
-  - libayatana-appindicator3-dev
-  - libkeybinder-3.0-dev
+  - libayatana-appindicator3-1
+  - libkeybinder-3.0-0
 
 keywords:
   - FlClash


### PR DESCRIPTION
**changes**
- replace `libayatana-appindicator3-dev` and `libkeybinder-3.0-dev` with `libayatana-appindicator3-1` and `libkeybinder-3.0-0`, these should work with ubuntu22.04, debian11 and newer deb-based distros. Users of legacy distros like ubuntu 20.04 may need some tricks to get it work.
- update READMEs indicating the change.
- tested on ubuntu 24.04 x64 and debian 13 arm64 using repacked deb.

**repackaged debs**
https://github.com/tianq02/FlClash/releases/tag/v0.8.92