### PR TITLE
Reduce macOS update task polling frequency

### DIFF
--- a/lib/state.dart
+++ b/lib/state.dart
@@ -119,9 +119,22 @@ class GlobalState {
       return;
     }
     await executorUpdateTask();
-    timer = Timer(const Duration(seconds: 1), () async {
+    final interval = await _resolveUpdateInterval();
+    timer = Timer(interval, () {
       startUpdateTasks();
     });
+  }
+
+  Future<Duration> _resolveUpdateInterval() async {
+    const defaultInterval = Duration(seconds: 1);
+    if (!system.isMacOS) {
+      return defaultInterval;
+    }
+    final visible = await window?.isVisible;
+    if (visible == false) {
+      return const Duration(seconds: 10);
+    }
+    return const Duration(seconds: 3);
   }
 
   Future<void> executorUpdateTask() async {


### PR DESCRIPTION
Motivation
The background update loop was scheduling tasks every second which can increase CPU usage and cause macOS devices to run hot, so the polling frequency should be relaxed on macOS and reduced further when the app window is hidden.
Description
Change startUpdateTasks to use a new helper _resolveUpdateInterval() and schedule the next run with the returned Duration; _resolveUpdateInterval() returns Duration(seconds: 1) by default, Duration(seconds: 3) on macOS when the window is visible, and Duration(seconds: 10) on macOS when the window is hidden.
Testing
No automated tests were run for this change.