### PR TITLE
feat(dashboard): 用代理参数启动独立浏览器

### DIFF
--- a/lib/views/dashboard/dashboard.dart
+++ b/lib/views/dashboard/dashboard.dart
@@ -250,7 +250,14 @@ class _DashboardViewState extends ConsumerState<DashboardView> {
       (isEdit) => CommonScaffold(
         title: appLocalizations.dashboard,
         actions: _buildActions(isEdit),
-        floatingActionButton: const StartButton(),
+        floatingActionButton: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            LaunchBrowserButton(),
+            SizedBox(width: 8),
+            StartButton(),
+          ],
+        ),
         body: Align(
           alignment: Alignment.topCenter,
           child: SingleChildScrollView(


### PR DESCRIPTION
在 启动 按钮 的左边，增加了一个启动浏览器按钮。

有些情况，有的系统有问题，软件的设置代理功能 会无法设置成功系统代理，导致很多小白以为软件不好用，或者认为是节点不工作。

增加这个启动浏览器按钮，会用flclash当前端口的代理参数启动一个独立浏览器窗口， 这样可以非常方便的证明软件和节点是好用的，只是系统有问题，系统代理无法设置成功。