### PR TITLE
Toggle window visibility on tray icon click

### DIFF
--- a/lib/manager/tray_manager.dart
+++ b/lib/manager/tray_manager.dart
@@ -54,8 +54,14 @@ class _TrayContainerState extends ConsumerState<TrayManager> with TrayListener {
   }
 
   @override
-  onTrayIconMouseDown() {
-    window?.show();
+  onTrayIconMouseDown() async {
+    final w = window;
+    if (w == null) return;
+    if (await w.isVisible) {
+      await w.hide();
+    } else {
+      await w.show();
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
- Clicking the tray icon now toggles window visibility instead of always showing the window
- If the window is visible, clicking hides it; if hidden, clicking shows it
- Uses existing `Window.isVisible`, `Window.hide()`, and `Window.show()` methods

## Test plan
- [ ] Click tray icon when window is hidden → window should appear
- [ ] Click tray icon when window is visible → window should hide
- [ ] Click tray icon again → window should reappear
- [ ] Right-click tray icon → context menu should work as before