### PR TITLE
Portable fix

### DIFF
--- a/lib/common/path.dart
+++ b/lib/common/path.dart
@@ -12,12 +12,11 @@ class AppPath {
   Completer<Directory> tempDir = Completer();
   Completer<Directory> cacheDir = Completer();
   late String appDirPath;
+  bool isPortable = false;
 
   AppPath._internal() {
     appDirPath = join(dirname(Platform.resolvedExecutable));
-    getApplicationSupportDirectory().then((value) {
-      dataDir.complete(value);
-    });
+    _initDataDir();
     getTemporaryDirectory().then((value) {
       tempDir.complete(value);
     });
@@ -27,6 +26,25 @@ class AppPath {
     getApplicationCacheDirectory().then((value) {
       cacheDir.complete(value);
     });
+  }
+
+  bool get _isDesktop =>
+      Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+
+  Future<void> _initDataDir() async {
+    // Portable mode: if a 'config' directory exists next to the executable on
+    // desktop platforms, use it as the data directory instead of the
+    // platform-specific application support directory.
+    if (_isDesktop) {
+      final portableConfigDir = Directory(join(appDirPath, 'config'));
+      if (await portableConfigDir.exists()) {
+        isPortable = true;
+        dataDir.complete(portableConfigDir);
+        return;
+      }
+    }
+    final dir = await getApplicationSupportDirectory();
+    dataDir.complete(dir);
   }
 
   factory AppPath() {


### PR DESCRIPTION
正在尝试修复 [https://github.com/chen08209/FlClash/issues/1882](https://github.com/chen08209/FlClash/issues/1882)

此拉取请求更新了 `lib/common/path.dart` 中的 `AppPath` 类，为桌面平台添加了便携模式支持。现在，如果可执行文件旁存在一个 `config` 目录，应用程序将使用该目录作为数据目录，而不是默认的平台特定位置。

**便携模式支持：**

* 添加了 `isPortable` 标志，用于指示应用程序是否以便携模式运行。
* 引入了 `_initDataDir` 方法，用于在桌面平台（Windows、macOS、Linux）上检查可执行文件旁是否存在 `config` 目录。如果找到，应用程序将使用该目录作为数据目录，并将 `isPortable` 设置为 true；否则，将回退到标准的应用程序支持目录。

仍在测试。