### PR TITLE
fix(linux): silent launching not working

### DIFF
--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -14,12 +14,6 @@ struct _MyApplication {
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 
-// Called when first Flutter frame received.
-static void first_frame_cb(MyApplication* self, FlView *view)
-{
-  gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
-}
-
 // Implements GApplication::activate.
 static void my_application_activate(GApplication* application) {
   MyApplication* self = MY_APPLICATION(application);
@@ -66,9 +60,8 @@ static void my_application_activate(GApplication* application) {
   gtk_widget_show(GTK_WIDGET(view));
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
-  // Show the window when Flutter renders.
-  // Requires the view to be realized so we can start rendering.
-  g_signal_connect_swapped(view, "first-frame", G_CALLBACK(first_frame_cb), self);
+  // Realize the view so Flutter can render even if the window stays hidden
+  // until Dart startup logic explicitly shows it.
   gtk_widget_realize(GTK_WIDGET(view));
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));


### PR DESCRIPTION
## Summary

Fix Linux silent launch so the app does not force the main window visible during startup.

## Fixes

Fixes #1767 
Fixes #1807 

## Testing

Verified in the following environment:
- OS: Arch Linux
- Desktop environment: KDE Plasma 6.6
- Session: Wayland