### PR TITLE
Restore Windows ARM64 build in GitHub Actions

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -27,7 +27,9 @@
             <td>Windows</td>
             <td>
                 <a href="https://github.com/chen08209/FlClash/releases/download/vVERSION/FlClash-VERSION-windows-amd64-setup.exe"><img src="https://img.shields.io/badge/Setup-x64-2d7d9a.svg?logo=windows"></a><br>
-                <a href="https://github.com/chen08209/FlClash/releases/download/vVERSION/FlClash-VERSION-windows-amd64.zip"><img src="https://img.shields.io/badge/Portable-x64-67b7d1.svg?logo=windows"></a>
+                <a href="https://github.com/chen08209/FlClash/releases/download/vVERSION/FlClash-VERSION-windows-amd64.zip"><img src="https://img.shields.io/badge/Portable-x64-67b7d1.svg?logo=windows"></a><br>
+                <a href="https://github.com/chen08209/FlClash/releases/download/vVERSION/FlClash-VERSION-windows-arm64-setup.exe"><img src="https://img.shields.io/badge/Setup-ARM64-005a9c.svg?logo=windows"></a><br>
+                <a href="https://github.com/chen08209/FlClash/releases/download/vVERSION/FlClash-VERSION-windows-arm64.zip"><img src="https://img.shields.io/badge/Portable-ARM64-4c9ed9.svg?logo=windows"></a>
             </td>
         </tr>
         <tr>

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,9 +27,9 @@ jobs:
           - platform: macos
             os: macos-latest
             arch: arm64
-          #          - platform: windows
-          #            os: windows-11-arm
-          #            arch: arm64
+          - platform: windows
+            os: windows-11-arm
+            arch: arm64
           - platform: linux
             os: ubuntu-24.04-arm
             arch: arm64
@@ -44,9 +44,20 @@ jobs:
           Add-Content $env:GITHUB_PATH $cargoPath
 
       - name: Checkout
+        if: ${{ !startsWith(matrix.os, 'windows-11-arm') }}
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Checkout (Windows ARM)
+        if: startsWith(matrix.os, 'windows-11-arm')
+        uses: actions/checkout@v4
+
+      - name: Setup submodules (Windows ARM)
+        if: startsWith(matrix.os, 'windows-11-arm')
+        run: |
+          git submodule sync --recursive
+          git submodule update --init --recursive
 
       - name: Setup Android Signing
         if: startsWith(matrix.platform,'android')

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,14 +1,14 @@
 [submodule "core/Clash.Meta"]
 	path = core/Clash.Meta
-	url = git@github.com:chen08209/Clash.Meta.git
+	url = https://github.com/chen08209/Clash.Meta.git
 	branch = FlClash
 [submodule "plugins/flutter_distributor"]
 	path = plugins/flutter_distributor
-	url = git@github.com:chen08209/flutter_distributor.git
+	url = https://github.com/chen08209/flutter_distributor.git
 	branch = FlClash
 [submodule "plugins/tray_manager"]
 	path = plugins/tray_manager
-	url = git@github.com:chen08209/tray_manager.git
+	url = https://github.com/chen08209/tray_manager.git
 	branch = main
 
 

--- a/release_telegram.py
+++ b/release_telegram.py
@@ -6,7 +6,7 @@ TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 TAG = os.getenv("TAG")
 RUN_ID = os.getenv("RUN_ID")
 
-IS_STABLE = "-" not in TAG
+IS_STABLE = TAG is not None and "-" not in TAG
 
 CHAT_ID = "@FlClash"
 API_URL = f"http://localhost:8081/bot{TELEGRAM_BOT_TOKEN}/sendMediaGroup"
@@ -23,6 +23,7 @@ i = 1
 
 releaseKeywords = [
     "windows-amd64-setup",
+    "windows-arm64-setup",
     "android-arm64",
     "macos-arm64",
     "macos-amd64"


### PR DESCRIPTION
## Summary

This PR restores the Windows ARM64 build pipeline in GitHub Actions and adjusts submodule checkout behavior for the `windows-11-arm` runner.

## Changes

- re-enable the Windows ARM64 build target in `.github/workflows/build.yaml`
- avoid `actions/checkout` recursive submodule checkout on `windows-11-arm`
- manually run `git submodule sync --recursive` and `git submodule update --init --recursive` for Windows ARM jobs
- switch submodule URLs in `.gitmodules` from SSH to HTTPS
- update release metadata to include Windows ARM64 download entries
- fix the `release_telegram.py` stable-release check to safely handle a missing `TAG`

## Why

The project already contains most of the Windows ARM64 build support, but the GitHub Actions workflow had the Windows ARM job disabled.

After re-enabling it, the `windows-11-arm` runner failed during the checkout/submodule phase when `actions/checkout@v4` used recursive submodule handling. This PR works around that runner-specific failure by using a normal checkout first and then initializing submodules manually.

Using HTTPS submodule URLs also avoids SSH-related issues in CI environments.

## Notes

- This PR intentionally focuses on restoring the Windows ARM64 build pipeline with the smallest possible workflow change.
- Manual workflow trigger changes were not included here.