### PR TITLE
Fix window close while search is active

### DIFF
--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -886,6 +886,22 @@ extension SystemControllerExt on AppController {
     }
   }
 
+  /// Window close that bypasses [backBlockProvider].
+  /// Used exclusively by the window title-bar close button, the
+  /// window-close system event, and the Ctrl+W shortcut so that
+  /// they always work even when a search / edit overlay has set
+  /// backBlock to true.
+  Future<void> handleWindowClose() async {
+    if (_ref.read(appSettingProvider).minimizeOnExit) {
+      if (system.isDesktop) {
+        await preferences.saveConfig(config);
+      }
+      await system.back();
+    } else {
+      await handleExit();
+    }
+  }
+
   Future<void> updateVisible() async {
     final visible = await window?.isVisible;
     if (visible != null && !visible) {

--- a/lib/manager/hotkey_manager.dart
+++ b/lib/manager/hotkey_manager.dart
@@ -78,7 +78,7 @@ class _HotKeyManagerState extends ConsumerState<HotKeyManager> {
       child: Actions(
         actions: {
           CloseWindowIntent: CallbackAction<CloseWindowIntent>(
-            onInvoke: (_) => appController.handleBackOrExit(),
+            onInvoke: (_) => appController.handleWindowClose(),
           ),
           DoNothingIntent: CallbackAction<DoNothingIntent>(
             onInvoke: (_) => null,

--- a/lib/manager/window_manager.dart
+++ b/lib/manager/window_manager.dart
@@ -44,7 +44,7 @@ class _WindowContainerState extends ConsumerState<WindowManager>
 
   @override
   void onWindowClose() async {
-    await appController.handleBackOrExit();
+    await appController.handleWindowClose();
     super.onWindowClose();
   }
 
@@ -220,7 +220,7 @@ class _WindowHeaderState extends State<WindowHeader> {
         ),
         IconButton(
           onPressed: () {
-            appController.handleBackOrExit();
+            appController.handleWindowClose();
           },
           icon: const Icon(Icons.close),
         ),


### PR DESCRIPTION
## Summary
- add a dedicated window close path that bypasses page-level back blocking
- use it for the title-bar close button, the desktop window close event, and the Ctrl+W shortcut
- keep in-page search and edit back interception unchanged

## Validation
- confirmed the close path now goes through handleWindowClose() instead of handleBackOrExit()
- confirmed system.back() on desktop hides the window directly, so it does not re-enter page back interception
- dart / lutter are not available in this environment, so lutter analyze and runtime verification could not be executed here