### PR TITLE
Add Ubuntu 20.04 Docker build environment and fix Linux compatibility

### DIFF
--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -116,6 +116,31 @@ on Mobile:
            dart .\setup.dart macos --arch <arm64 | amd64>
            ```
 
+### Ubuntu20 Docker 一键打包
+
+如果你希望在统一的 Ubuntu20 环境中构建 Linux 安装包，可直接使用仓库内脚本：
+
+1. 确保本机已安装 Docker
+2. 在项目根目录执行：
+
+   ```bash
+   ./build_deb_in_docker.sh
+   ```
+
+   或构建 arm64 包：
+
+   ```bash
+   ./build_deb_in_docker.sh arm64
+   ```
+
+说明：
+
+- Docker 基础镜像为 `ubuntu:20.04`，构建环境使用清华源（apt / dart pub / go proxy）
+- amd64 默认输出 `deb`、`AppImage`、`rpm` 三种格式；可通过 `FLCLASH_LINUX_TARGETS=deb` 仅构建 deb
+- 在 Ubuntu 20.04 容器内构建，保证所有打包库基于 GLib 2.64，不会出现 `g_time_zone_new_identifier` 等符号兼容问题
+- 构建产物会复制到项目根目录，便于直接安装
+- 如需自定义镜像名：`IMAGE_NAME=your-name ./build_deb_in_docker.sh`
+
 ## Star History
 
 支持开发者的最简单方式是点击页面顶部的星标（⭐）。

--- a/build_deb_in_docker.sh
+++ b/build_deb_in_docker.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE_NAME="${IMAGE_NAME:-flclash-deb-builder:ubuntu20}"
+ARCH="${1:-amd64}"
+
+if [[ "${ARCH}" != "amd64" && "${ARCH}" != "arm64" ]]; then
+  echo "unsupported arch: ${ARCH}, allowed: amd64|arm64"
+  exit 1
+fi
+
+cd "${SCRIPT_DIR}"
+
+# ---------- 0. init submodules on host (SSH keys available here) ----------
+if [ -f .gitmodules ]; then
+  echo "[0/3] initialising git submodules on host ..."
+  git submodule update --init --recursive || \
+    echo "  warn: host submodule init failed; will retry inside container via HTTPS"
+fi
+
+# ---------- 1. build docker image ----------
+echo "[1/3] building docker image: ${IMAGE_NAME}"
+docker build -f docker/ubuntu20-deb.Dockerfile -t "${IMAGE_NAME}" .
+
+# ---------- 2. build deb inside container ----------
+echo "[2/3] building deb package inside container (arch=${ARCH}) ..."
+docker run --rm \
+  -v "${SCRIPT_DIR}:/work" \
+  -v flclash-pub-cache:/root/.pub-cache \
+  -v flclash-go-mod:/root/go/pkg/mod \
+  -v flclash-go-build:/root/.cache/go-build \
+  -w /work \
+  -e APPIMAGE_EXTRACT_AND_RUN=1 \
+  "${IMAGE_NAME}" \
+  bash -lc "
+    set -euo pipefail
+
+    # Ensure submodules are present (HTTPS rewrite is in image git config)
+    git submodule update --init --recursive
+
+    flutter pub get
+
+    # Build all default targets (deb + appimage + rpm on amd64, deb on arm64).
+    # Building inside Ubuntu 20.04 ensures bundled libs are ABI-compatible.
+    dart setup.dart linux --arch ${ARCH} --env stable
+  "
+
+# ---------- 3. collect output ----------
+echo "[3/3] copying packages to project root ..."
+found=0
+for ext in deb AppImage rpm; do
+  if compgen -G "${SCRIPT_DIR}/dist/*.${ext}" > /dev/null; then
+    cp -fv "${SCRIPT_DIR}"/dist/*.${ext} "${SCRIPT_DIR}/"
+    found=1
+  fi
+done
+
+if [ "${found}" -eq 1 ]; then
+  echo ""
+  echo "===== done ====="
+  ls -lh "${SCRIPT_DIR}"/*.deb "${SCRIPT_DIR}"/*.AppImage "${SCRIPT_DIR}"/*.rpm 2>/dev/null || true
+else
+  echo "error: no packages found under dist/. Build may have failed."
+  exit 2
+fi

--- a/docker/ubuntu20-deb.Dockerfile
+++ b/docker/ubuntu20-deb.Dockerfile
@@ -1,0 +1,77 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Asia/Shanghai
+
+# ---------- 1. Tsinghua apt mirror + system packages ----------
+# HTTP before ca-certificates is installed to avoid TLS bootstrap issues.
+RUN sed -i 's@http://archive.ubuntu.com/ubuntu/@http://mirrors.tuna.tsinghua.edu.cn/ubuntu/@g' /etc/apt/sources.list \
+    && sed -i 's@http://security.ubuntu.com/ubuntu/@http://mirrors.tuna.tsinghua.edu.cn/ubuntu/@g' /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        clang \
+        cmake \
+        curl \
+        file \
+        git \
+        libayatana-appindicator3-dev \
+        libfuse2 \
+        libgtk-3-dev \
+        libkeybinder-3.0-dev \
+        liblzma-dev \
+        libsecret-1-dev \
+        mlocate \
+        ninja-build \
+        patchelf \
+        pkg-config \
+        rpm \
+        sudo \
+        unzip \
+        wget \
+        xz-utils \
+        zip \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------- 2. Go (Aliyun mirror; Tsinghua golang mirror is gone) ----------
+ARG GO_VERSION=1.24.1
+ARG TARGETARCH=amd64
+RUN curl -fsSL \
+        "https://mirrors.aliyun.com/golang/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
+        -o /tmp/go.tgz \
+    && tar -C /usr/local -xzf /tmp/go.tgz \
+    && rm -f /tmp/go.tgz
+
+# ---------- 3. Flutter (tarball from flutter-io.cn, much faster than git clone) ----------
+ARG FLUTTER_VERSION=3.35.7
+RUN curl -fSL \
+        "https://storage.flutter-io.cn/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" \
+        -o /tmp/flutter.tar.xz \
+    && mkdir -p /opt \
+    && tar -xJf /tmp/flutter.tar.xz -C /opt \
+    && rm -f /tmp/flutter.tar.xz
+
+# ---------- 4. Environment ----------
+ENV PATH="/opt/flutter/bin:/opt/flutter/bin/cache/dart-sdk/bin:/usr/local/go/bin:/root/.pub-cache/bin:${PATH}"
+ENV PUB_HOSTED_URL="https://mirrors.tuna.tsinghua.edu.cn/dart-pub"
+ENV FLUTTER_STORAGE_BASE_URL="https://storage.flutter-io.cn"
+ENV GOPROXY="https://goproxy.cn,direct"
+
+# Rewrite SSH submodule URLs to HTTPS so cloning works without SSH keys,
+# and mark any mounted volume as safe for git.
+RUN git config --global url."https://github.com/".insteadOf "git@github.com:" \
+    && git config --global --add safe.directory '*'
+
+WORKDIR /work
+
+# ---------- 5. Extra build deps (separate layer to preserve Flutter cache) ----------
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends g++ libx11-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------- 6. Pre-cache toolchains ----------
+RUN flutter config --enable-linux-desktop \
+    && flutter --disable-analytics \
+    && flutter --version \
+    && dart --version \
+    && go version

--- a/lib/common/constant.dart
+++ b/lib/common/constant.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: constant_identifier_names
 
+import 'dart:io';
 import 'dart:math';
 import 'dart:ui';
 
@@ -59,11 +60,13 @@ const defaultExternalController = '127.0.0.1:9090';
 const maxMobileWidth = 600;
 const maxLaptopWidth = 840;
 const defaultTestUrl = 'https://www.gstatic.com/generate_204';
-final commonFilter = ImageFilter.blur(
-  sigmaX: 5,
-  sigmaY: 5,
-  tileMode: TileMode.mirror,
-);
+final ImageFilter? commonFilter = Platform.isLinux
+    ? null
+    : ImageFilter.blur(
+        sigmaX: 5,
+        sigmaY: 5,
+        tileMode: TileMode.mirror,
+      );
 
 const listEquality = ListEquality();
 const navigationItemListEquality = ListEquality<NavigationItem>();

--- a/linux/runner/CMakeLists.txt
+++ b/linux/runner/CMakeLists.txt
@@ -20,7 +20,10 @@ apply_standard_settings(${BINARY_NAME})
 add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
 
 # Add dependency libraries. Add any application-specific dependencies here.
+find_package(X11 REQUIRED)
 target_link_libraries(${BINARY_NAME} PRIVATE flutter)
 target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+target_link_libraries(${BINARY_NAME} PRIVATE ${X11_LIBRARIES})
+target_include_directories(${BINARY_NAME} PRIVATE ${X11_INCLUDE_DIR})
 
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")

--- a/linux/runner/main.cc
+++ b/linux/runner/main.cc
@@ -1,6 +1,8 @@
 #include "my_application.h"
+#include <X11/Xlib.h>
 
 int main(int argc, char** argv) {
+  XInitThreads();
   g_autoptr(MyApplication) app = my_application_new();
   return g_application_run(G_APPLICATION(app), argc, argv);
 }

--- a/setup.dart
+++ b/setup.dart
@@ -479,11 +479,16 @@ class BuildCommand extends Command {
         return;
       case Target.linux:
         final targetMap = {Arch.arm64: 'linux-arm64', Arch.amd64: 'linux-x64'};
-        final targets = [
-          'deb',
-          if (arch == Arch.amd64) 'appimage',
-          if (arch == Arch.amd64) 'rpm',
-        ].join(',');
+        final customLinuxTargets =
+            Platform.environment['FLCLASH_LINUX_TARGETS']?.trim();
+        final targets = (customLinuxTargets != null &&
+                customLinuxTargets.isNotEmpty)
+            ? customLinuxTargets
+            : [
+                'deb',
+                if (arch == Arch.amd64) 'appimage',
+                if (arch == Arch.amd64) 'rpm',
+              ].join(',');
         final defaultTarget = targetMap[arch];
         await _getLinuxDependencies(arch!);
         _buildDistributor(


### PR DESCRIPTION
- Add docker/ubuntu20-deb.Dockerfile and build_deb_in_docker.sh for one-click packaging (deb/AppImage/rpm) inside an Ubuntu 20.04 container, with Tsinghua/Aliyun mirrors for apt, dart pub, go proxy.
- Call XInitThreads() in linux/runner/main.cc and link libX11 to fix XCB multi-thread assertion crash on Ubuntu 20.04 X11 stack.
- Disable ImageFilter.blur backdrop on Linux (lib/common/constant.dart) to avoid full-window blur rendering artifacts on older Mesa/GPU drivers.
- Support FLCLASH_LINUX_TARGETS env var in setup.dart to allow customizing Linux packaging targets (e.g. deb-only).
- Update README_zh_CN.md with Docker build instructions.