### PR TITLE
fix: resolve_process JNI 空指针导致 :remote 进程 SIGABRT

### DIFF
--- a/android/core/src/main/cpp/core.cpp
+++ b/android/core/src/main/cpp/core.cpp
@@ -105,6 +105,9 @@ call_tun_interface_resolve_process_impl(void *tun_interface, const int protocol,
                                         const char *source,
                                         const char *target,
                                         const int uid) {
+    if (tun_interface == nullptr) {
+        return strdup("");
+    }
     ATTACH_JNI();
     const auto packageName = reinterpret_cast<jstring>(env->CallObjectMethod(
             static_cast<jobject>(tun_interface),

--- a/core/lib.go
+++ b/core/lib.go
@@ -84,7 +84,7 @@ func (th *TunHandler) handleResolveProcess(source, target net.Addr) string {
 	_ = th.limit.Acquire(context.Background(), 1)
 	defer th.limit.Release(1)
 
-	if th.listener == nil {
+	if th.listener == nil || th.callback == nil {
 		return ""
 	}
 	var protocol int


### PR DESCRIPTION
## 问题

Android 端启动 VPN 代理后，`:remote` 进程在约 2 秒内以 SIGABRT 崩溃。退出应用重新打开代理同样 2 秒内再次崩溃。VPN 完全无法使用。

详细分析见 #1995

## 崩溃信息

```
JNI DETECTED ERROR IN APPLICATION: obj == null
    in call to CallObjectMethodV
#08 libclash.so (_cgo_4e86939d2e9c_Cfunc_resolve_process+48)
```

## 修复内容

两处空指针检查：

1. **`core/lib.go`** — `handleResolveProcess` 增加 `th.callback == nil` 检查，避免将空指针传入 CGO
2. **`android/core/src/main/cpp/core.cpp`** — `call_tun_interface_resolve_process_impl` 增加 `tun_interface == nullptr` 检查，避免对空 jobject 调用 JNI 方法

## 测试计划

- [ ] 验证 VPN 启动后不再崩溃
- [ ] 验证退出重开后代理功能正常