### PR TITLE
update wifi_ssid_plugin.cpp

### DIFF
--- a/plugins/wifi_ssid/windows/wifi_ssid_plugin.cpp
+++ b/plugins/wifi_ssid/windows/wifi_ssid_plugin.cpp
@@ -85,7 +85,7 @@ void WifiSsidPlugin::GetSsid(
   for (DWORD i = 0; i < pIfList->dwNumberOfItems; i++) {
     PWLAN_CONNECTION_ATTRIBUTES pConnAttrib = nullptr;
     DWORD dwDataSize = sizeof(WLAN_CONNECTION_ATTRIBUTES);
-    DWORD opCode = wlan_intf_opcode_current_connection;
+    WLAN_INTF_OPCODE opCode = wlan_intf_opcode_current_connection;
 
     dwResult = WlanQueryInterface(
         hClient, &pIfList->InterfaceInfo[i].InterfaceGuid, opCode, nullptr,


### PR DESCRIPTION
Build Tools for Visual Studio 2026, MSVC v143
编译windows amd64 pre报错：
C:\b\s\w\ir\x\w\sdk\pkg\dartdev\bin\dartdev.dart 13  main
[  +13 ms] D:\GitHub\FlClash\windows\flutter\ephemeral\.plugin_symlinks\wifi_ssid\windows\wifi_ssid_plugin.cpp(90,16): error C2664: “DWORD WlanQueryInterface(HANDLE,const GUID *,WLAN_INTF_OPCODE,PVOID,PDWORD,PVOID *,PWLAN_OPCODE_VALUE_TYPE)”: 无法将参数 3 从“DWORD”转换为“WLAN_INTF_OPCODE” [D:\GitHub\FlClash\build
\windows\x64\plugins\wifi_ssid\wifi_ssid_plugin.vcxproj]
[        ]   D:\GitHub\FlClash\windows\flutter\ephemeral\.plugin_symlinks\wifi_ssid\windows\wifi_ssid_plugin.cpp(90,16): error C2664: “DWORD WlanQueryInterface(HANDLE,const GUID *,WLAN_INTF_OPCODE,PVOID,PDWORD,PVOID *,PWLAN_OPCODE_VALUE_TYPE)”: 无法将参数 3 从“DWORD”转换为“WLAN_INTF_OPCODE” 

第88行“DWORD”修改为“WLAN_INTF_OPCODE” 