### PR TITLE
fix(dashboard): display runtime over 24h in day format with auto-adaptive button width

### DIFF
--- a/lib/common/utils.dart
+++ b/lib/common/utils.dart
@@ -76,26 +76,24 @@ class Utils {
   }
 
   String getTimeDifference(DateTime dateTime) {
-    var currentDateTime = DateTime.now();
-    var difference = currentDateTime.difference(dateTime);
-    var inHours = difference.inHours;
-    var inMinutes = difference.inMinutes;
-    var inSeconds = difference.inSeconds;
-
-    return '${getDateStringLast2(inHours)}:${getDateStringLast2(inMinutes)}:${getDateStringLast2(inSeconds)}';
+    final difference = DateTime.now().difference(dateTime);
+    return getTimeText(difference.inMilliseconds);
   }
 
   String getTimeText(int? timeStamp) {
     if (timeStamp == null) {
       return '00:00:00';
     }
-    final diff = timeStamp / 1000;
-    final inHours = (diff / 3600).floor();
-    if (inHours > 99) {
-      return '99:59:59';
+    final totalSeconds = (timeStamp / 1000).floor();
+    final inHours = (totalSeconds / Duration.secondsPerHour).floor();
+    final inMinutes = (totalSeconds / Duration.secondsPerMinute).floor() % 60;
+    final inSeconds = totalSeconds % 60;
+
+    if (inHours >= 24) {
+      final inDays = (inHours / 24).floor();
+      final remainHours = inHours % 24;
+      return '${inDays}d ${getDateStringLast2(remainHours)}:${getDateStringLast2(inMinutes)}:${getDateStringLast2(inSeconds)}';
     }
-    final inMinutes = (diff / 60 % 60).floor();
-    final inSeconds = (diff % 60).floor();
 
     return '${getDateStringLast2(inHours)}:${getDateStringLast2(inMinutes)}:${getDateStringLast2(inSeconds)}';
   }

--- a/lib/views/dashboard/widgets/start_button.dart
+++ b/lib/views/dashboard/widgets/start_button.dart
@@ -19,6 +19,8 @@ class _StartButtonState extends ConsumerState<StartButton>
   AnimationController? _controller;
   late Animation<double> _animation;
   bool isStart = false;
+  double? _cachedShortWidth;
+  double? _cachedLongWidth;
 
   @override
   void initState() {
@@ -66,6 +68,17 @@ class _StartButtonState extends ConsumerState<StartButton>
     });
   }
 
+  double _measureTextWidth(String text, BuildContext context) {
+    return globalState.measure
+        .computeTextSize(
+          Text(
+            text,
+            style: context.textTheme.titleMedium?.toSoftBold,
+          ),
+        )
+        .width;
+  }
+
   @override
   Widget build(BuildContext context) {
     final hasProfile = ref.watch(
@@ -83,17 +96,14 @@ class _StartButtonState extends ConsumerState<StartButton>
       ),
       child: AnimatedBuilder(
         animation: _controller!.view,
-        builder: (_, child) {
-          final textWidth =
-              globalState.measure
-                  .computeTextSize(
-                    Text(
-                      utils.getTimeDifference(DateTime.now()),
-                      style: context.textTheme.titleMedium?.toSoftBold,
-                    ),
-                  )
-                  .width +
-              16;
+        builder: (_, __) {
+          final runTime = ref.watch(runTimeProvider);
+          final text = utils.getTimeText(runTime);
+          final isLongFormat = text.contains('d ');
+          final cachedWidth = isLongFormat
+              ? _cachedLongWidth ??= _measureTextWidth('00d 00:00:00', context)
+              : _cachedShortWidth ??= _measureTextWidth('00:00:00', context);
+          final textWidth = cachedWidth + 16;
           return FloatingActionButton(
             clipBehavior: Clip.antiAlias,
             materialTapTargetSize: MaterialTapTargetSize.padded,
@@ -113,24 +123,22 @@ class _StartButtonState extends ConsumerState<StartButton>
                     progress: _animation,
                   ),
                 ),
-                SizedBox(width: textWidth * _animation.value, child: child!),
+                SizedBox(
+                  width: textWidth * _animation.value,
+                  child: Text(
+                    text,
+                    maxLines: 1,
+                    overflow: TextOverflow.visible,
+                    style: Theme.of(context).textTheme.titleMedium?.toSoftBold
+                        .copyWith(
+                          color: context.colorScheme.onPrimaryContainer,
+                        ),
+                  ),
+                ),
               ],
             ),
           );
         },
-        child: Consumer(
-          builder: (_, ref, _) {
-            final runTime = ref.watch(runTimeProvider);
-            final text = utils.getTimeText(runTime);
-            return Text(
-              text,
-              maxLines: 1,
-              overflow: TextOverflow.visible,
-              style: Theme.of(context).textTheme.titleMedium?.toSoftBold
-                  .copyWith(color: context.colorScheme.onPrimaryContainer),
-            );
-          },
-        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
Improve dashboard runtime display for long-running sessions by switching to day format after 24 hours.

## Problem
Issue #1824: dashboard runtime in the bottom-right stop button no longer increases visually after reaching `99:59:59`.

## Changes
- Switch to day format (`Xd HH:mm:ss`) when runtime reaches 24 hours instead of capping at `99:59:59`.
  - `< 24h`: `HH:mm:ss`
  - `>= 24h`: `Xd HH:mm:ss`
- Cache text width measurement in start button to avoid per-frame recalculation.
- Refactor `StartButton` to use `runTimeProvider` directly instead of `DateTime.now()`.

## Files
- `lib/common/utils.dart`
- `lib/views/dashboard/widgets/start_button.dart`

## Test
<img width="680" height="580" alt="image" src="https://github.com/user-attachments/assets/7fee90e4-8ebd-4c12-aec0-0eb3933ec8fc" />

Fixes #1824