### PR TITLE
Fix: 规则缺少 TARGET 字段导致 proxy not found 错误

### DIFF
--- a/lib/common/task.dart
+++ b/lib/common/task.dart
@@ -73,6 +73,43 @@ Future<List<Group>> _toGroupsTask(ComputeGroupsState state) async {
   );
 }
 
+const _ruleParams = {'no-resolve', 'src'};
+
+/// Fixes rules that are missing a TARGET field.
+///
+/// Some subscription sources produce rules like `IP-CIDR,192.133.76.0/22,no-resolve`
+/// where `no-resolve` is a parameter but the TARGET (proxy name) is missing.
+/// This inserts a default TARGET to prevent mihomo from treating the parameter
+/// as a proxy name.
+List<String> _fixRules(List<String> rules) {
+  String defaultTarget = 'DIRECT';
+  for (final rule in rules.reversed) {
+    final parts = rule.split(',');
+    final nonParams = parts.where((p) => !_ruleParams.contains(p)).toList();
+    if (nonParams.isNotEmpty && nonParams.first == 'MATCH') {
+      if (nonParams.length >= 2 && nonParams.last.isNotEmpty) {
+        defaultTarget = nonParams.last;
+      }
+      break;
+    }
+  }
+
+  return rules.map((rule) {
+    final parts = rule.split(',');
+    final nonParams = parts.where((p) => !_ruleParams.contains(p)).toList();
+    if (nonParams.length < 2) return rule;
+    final first = nonParams.first;
+    final isMatch = first == 'MATCH';
+    final isSubRule = first == 'SUB-RULE';
+    if (isMatch || isSubRule) return rule;
+    // A well-formed rule has at least: TYPE, CONTENT, TARGET (3 non-param parts)
+    if (nonParams.length >= 3) return rule;
+    // Missing TARGET: nonParams is [TYPE, CONTENT]. Insert defaultTarget.
+    final params = parts.where((p) => _ruleParams.contains(p)).toList();
+    return [...nonParams, defaultTarget, ...params].join(',');
+  }).toList();
+}
+
 Future<Map<String, dynamic>> makeRealProfileTask(
   MakeRealProfileState data,
 ) async {
@@ -214,6 +251,7 @@ Future<Map<String, dynamic>> _makeRealProfileTask(
     rules = List<String>.from(rawConfig['rules']);
   }
   rawConfig.remove('rules');
+  rules = _fixRules(rules);
   if (addedRules.isNotEmpty) {
     final parsedNewRules = addedRules
         .map((item) => ParsedRule.parseString(item.value))


### PR DESCRIPTION
# Fix: 规则缺少 TARGET 字段导致 proxy not found 错误

- **分支**: fix/rule-missing-target
- **日期**: 2026-05-20

## 问题描述

部分订阅源 (如：shadowsocks) 生成的规则缺少 TARGET（代理目标）字段，例如：

```
IP-CIDR,192.133.76.0/22,no-resolve
```

mihomo 引擎按逗号分割后将 `no-resolve` 误认为代理名，报错：

```
rules[227] [IP-CIDR,192.133.76.0/22,no-resolve] error: proxy [no-resolve] not found
```

正确的规则格式应为：

```
IP-CIDR,192.133.76.0/22,DIRECT,no-resolve
```

## 修改文件

### `lib/common/task.dart`

1. 新增 `_fixRules` 函数（第 76-111 行）
   - 检测规则中非参数部分少于 3 段（TYPE, CONTENT, TARGET）的情况
   - 自动插入默认 TARGET 字段
   - 默认使用 `DIRECT`；若规则列表中存在 `MATCH` 规则，则使用其 TARGET

2. 在 `_makeRealProfileTask` 中调用 `_fixRules`（第 254 行）
   - 在原始 rules 写入 `rawConfig` 之前进行修复

## 影响范围

- 仅影响从订阅配置读取的原始规则列表，不影响用户手动添加的规则
- 对格式正确的规则无任何影响（3 段及以上的规则直接跳过）
- MATCH 和 SUB-RULE 类型的规则不做处理
