### PR TITLE
fix: correct typo in system proxy enable

### DIFF
--- a/lib/manager/proxy_manager.dart
+++ b/lib/manager/proxy_manager.dart
@@ -24,7 +24,7 @@ class _ProxyManagerState extends ConsumerState<ProxyManager> {
     final port = proxyState.port;
     bool? result;
     if (isStart && systemProxy) {
-      result = await proxy?.startProxy(port, proxyState.bassDomain);
+      result = await proxy?.startProxy(port, proxyState.bypassDomain);
     } else {
       result = await proxy?.stopProxy();
     }


### PR DESCRIPTION
## Bug Description

System proxy enable was failing on Windows because of a typo in proxy_manager.dart.

## Root Cause

Line 27 had proxyState.bassDomain instead of proxyState.bypassDomain.

This caused the startProxy() method call to fail because the ypassDomain parameter was not being passed correctly to the native plugin.

## Why Close Worked but Open Didn't

- **stopProxy()** doesn't require any parameters, so it worked fine
- **startProxy(port, bypassDomain)** requires the bypassDomain parameter, which was 
ull due to the typo

## Fix

Changed assDomain to ypassDomain on line 27.

## Testing

- [x] Verified the fix resolves the system proxy enable issue
- [x] Confirmed stop proxy still works correctly

Fixes: System proxy toggle fails to enable on Windows