### PR TITLE
fix(linux): add startup_wm_class to fix taskbar icon on KDE

### DIFF
--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -26,3 +26,4 @@ categories:
   - Network
 
 startup_notify: true
+startup_wm_class: com.follow.clash


### PR DESCRIPTION
   Problem
    
    On KDE Plasma (Wayland), the FlClash window's resourceClass is com.follow.clash. The current .desktop file lacks StartupWMClass, causing the taskbar to fail to correctly associate the window with the application icon.
    
    Root Cause
    
    Flutter apps commonly use a different WM_CLASS than the binary name. Without explicitly setting StartupWMClass in the desktop entry, desktop environments cannot match the window properly.
    
    Solution
    
    Added startup_wm_class: com.follow.clash in linux/packaging/deb/make_config.yaml.
    
    This requires the corresponding support in flutter_distributor (see linked PR).
    
    Related Changes
    
    - flutter_distributor: https://github.com/chen08209/flutter_distributor/pull/1
    
    Reference
    
    - Desktop Entry Specification - StartupWMClass
   https://specifications.freedesktop.org/desktop-entry/latest-single/