### PR TITLE
为项目添加 github 的 Provenance 机制

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -247,6 +247,12 @@ jobs:
           version=$(echo "${{ github.ref_name }}" | sed 's/^v//')
           sed "s|VERSION|$version|g" ./.github/release_template.md >> release.md
 
+      - name: Attest build provenance
+        if: ${{ env.IS_STABLE == 'true' }}
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: './dist/*'
+
       - name: Generate sha256
         if: ${{ env.IS_STABLE == 'true' }}
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,8 +39,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - platform: android
-            os: ubuntu-latest
           - platform: windows
             os: Windows-2022
             arch: amd64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -230,7 +230,14 @@ jobs:
             git log --no-merges --pretty=format:"%B" "$range" | \
             awk '!/Update changelog/ && NF {print "- " $0 "\n"}' >> "$out"
           done
+      - name: Attest build provenance
+        if: ${{ env.IS_STABLE == 'true' }}
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: './dist/*'
+
       - name: Push to telegram
+        continue-on-error: true
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TAG: ${{ github.ref_name }}
@@ -244,12 +251,6 @@ jobs:
         run: |
           version=$(echo "${{ github.ref_name }}" | sed 's/^v//')
           sed "s|VERSION|$version|g" ./.github/release_template.md >> release.md
-
-      - name: Attest build provenance
-        if: ${{ env.IS_STABLE == 'true' }}
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: './dist/*'
 
       - name: Generate sha256
         if: ${{ env.IS_STABLE == 'true' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -237,7 +237,6 @@ jobs:
           subject-path: './dist/*'
 
       - name: Push to telegram
-        continue-on-error: true
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TAG: ${{ github.ref_name }}


### PR DESCRIPTION
这个 PR 为发布工作流接入了 GitHub 的 Provenance 机制，也就是 GitHub Artifact Attestations。

作为一个比较敏感的项目，安全性是极其重要的。

Provenance 机制的作用是给最终构建产物附上一份可验证的来源证明。验证方可以确认这些安装包或二进制确实是由本仓库、指定 workflow、指定 commit，在 GitHub Actions 中构建出来的，而不是手工替换或来自未知构建环境。

前段时间引发广泛关注的 Linux xz 后门事件，就是典型的“源码是干净的，但发布的预编译二进制文件被投毒了”。也说明了软件供应链里“发布产物”本身的可信性非常重要。问题不一定只出在公开源码层，也可能出现在实际构建、打包、分发出来的二进制产物上。Provenance 机制提供的正是这类“来源可验证性”，帮助下游确认拿到的文件来自预期的官方构建链路。