### PR TITLE
fix: propagate UID from getConnectionOwnerUid through JNI bridge

### DIFF
--- a/android/service/src/main/java/com/follow/clash/service/VpnService.kt
+++ b/android/service/src/main/java/com/follow/clash/service/VpnService.kt
@@ -70,7 +70,8 @@ class VpnService : SystemVpnService(), IBaseService,
         if (!uidPageNameMap.containsKey(nextUid)) {
             uidPageNameMap[nextUid] = this.packageManager?.getPackagesForUid(nextUid)?.first() ?: ""
         }
-        return uidPageNameMap[nextUid] ?: ""
+        val packageName = uidPageNameMap[nextUid] ?: ""
+        return "$nextUid\n$packageName"
     }
 
     val VpnOptions.address

--- a/core/lib.go
+++ b/core/lib.go
@@ -21,6 +21,7 @@ import (
 	"github.com/metacubex/mihomo/log"
 	"golang.org/x/sync/semaphore"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -115,7 +116,14 @@ func (th *TunHandler) initHook() {
 		if src == nil || dst == nil {
 			return "", process.ErrInvalidNetwork
 		}
-		return tunHandler.handleResolveProcess(src, dst), nil
+		result := tunHandler.handleResolveProcess(src, dst)
+		if parts := strings.SplitN(result, "\n", 2); len(parts) == 2 {
+			if uid, err := strconv.ParseUint(parts[0], 10, 32); err == nil {
+				metadata.Uid = uint32(uid)
+			}
+			return parts[1], nil
+		}
+		return result, nil
 	}
 }
 


### PR DESCRIPTION
## Summary

- `resolverProcess()` already calls `getConnectionOwnerUid()` and gets the correct kernel UID, but the JNI bridge discards it — only the package name string is returned
- `metadata.Uid` is always 0, making `UID` routing rules non-functional on Android Q+
- Fix: encode UID in return string as `"uid\npackageName"`, parse on Go side to set `metadata.Uid`

**2 files changed, ~10 lines added.** No changes to C/JNI signatures, bride.h/c/go, or TunInterface.kt.

Closes #2100

🤖 Generated with [Claude Code](https://claude.com/claude-code)