### PR TITLE
feat: add custom User-Agent support for profiles

### DIFF
--- a/lib/common/request.dart
+++ b/lib/common/request.dart
@@ -31,11 +31,14 @@ class Request {
     );
   }
 
-  Future<Response<Uint8List>> getFileResponseForUrl(String url) async {
+  Future<Response<Uint8List>> getFileResponseForUrl(String url, {String? userAgent}) async {
     try {
       return await _clashDio.get<Uint8List>(
         url,
-        options: Options(responseType: ResponseType.bytes),
+        options: Options(
+          responseType: ResponseType.bytes,
+          headers: userAgent != null ? {'User-Agent': userAgent} : null,
+        ),
       );
     } catch (e) {
       commonPrint.log('getFileResponseForUrl error ${e.toString()}');

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -33,7 +33,7 @@ class Database extends _$Database {
   Database([QueryExecutor? executor]) : super(executor ?? _openConnection());
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
 
   static LazyDatabase _openConnection() {
     return LazyDatabase(() async {
@@ -51,6 +51,13 @@ class Database extends _$Database {
           await m.createTable(iconRecords);
           await _resetOrders();
           await _migrateRules(m);
+        }
+        if (from < 3) {
+          try {
+            await m.addColumn(profiles, profiles.userAgent);
+          } catch (_) {
+            // Ignore if column already exists
+          }
         }
       },
       beforeOpen: (details) async {

--- a/lib/database/generated/database.g.dart
+++ b/lib/database/generated/database.g.dart
@@ -38,6 +38,17 @@ class $ProfilesTable extends Profiles
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _userAgentMeta = const VerificationMeta(
+    'userAgent',
+  );
+  @override
+  late final GeneratedColumn<String> userAgent = GeneratedColumn<String>(
+    'user_agent',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _urlMeta = const VerificationMeta('url');
   @override
   late final GeneratedColumn<String> url = GeneratedColumn<String>(
@@ -145,6 +156,7 @@ class $ProfilesTable extends Profiles
     id,
     label,
     currentGroupName,
+    userAgent,
     url,
     lastUpdateDate,
     overwriteType,
@@ -186,6 +198,12 @@ class $ProfilesTable extends Profiles
           data['current_group_name']!,
           _currentGroupNameMeta,
         ),
+      );
+    }
+    if (data.containsKey('user_agent')) {
+      context.handle(
+        _userAgentMeta,
+        userAgent.isAcceptableOrUnknown(data['user_agent']!, _userAgentMeta),
       );
     }
     if (data.containsKey('url')) {
@@ -256,6 +274,10 @@ class $ProfilesTable extends Profiles
       currentGroupName: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}current_group_name'],
+      ),
+      userAgent: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}user_agent'],
       ),
       url: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
@@ -329,6 +351,7 @@ class RawProfile extends DataClass implements Insertable<RawProfile> {
   final int id;
   final String label;
   final String? currentGroupName;
+  final String? userAgent;
   final String url;
   final DateTime? lastUpdateDate;
   final OverwriteType overwriteType;
@@ -343,6 +366,7 @@ class RawProfile extends DataClass implements Insertable<RawProfile> {
     required this.id,
     required this.label,
     this.currentGroupName,
+    this.userAgent,
     required this.url,
     this.lastUpdateDate,
     required this.overwriteType,
@@ -361,6 +385,9 @@ class RawProfile extends DataClass implements Insertable<RawProfile> {
     map['label'] = Variable<String>(label);
     if (!nullToAbsent || currentGroupName != null) {
       map['current_group_name'] = Variable<String>(currentGroupName);
+    }
+    if (!nullToAbsent || userAgent != null) {
+      map['user_agent'] = Variable<String>(userAgent);
     }
     map['url'] = Variable<String>(url);
     if (!nullToAbsent || lastUpdateDate != null) {
@@ -406,6 +433,9 @@ class RawProfile extends DataClass implements Insertable<RawProfile> {
       currentGroupName: currentGroupName == null && nullToAbsent
           ? const Value.absent()
           : Value(currentGroupName),
+      userAgent: userAgent == null && nullToAbsent
+          ? const Value.absent()
+          : Value(userAgent),
       url: Value(url),
       lastUpdateDate: lastUpdateDate == null && nullToAbsent
           ? const Value.absent()
@@ -436,6 +466,7 @@ class RawProfile extends DataClass implements Insertable<RawProfile> {
       id: serializer.fromJson<int>(json['id']),
       label: serializer.fromJson<String>(json['label']),
       currentGroupName: serializer.fromJson<String?>(json['currentGroupName']),
+      userAgent: serializer.fromJson<String?>(json['userAgent']),
       url: serializer.fromJson<String>(json['url']),
       lastUpdateDate: serializer.fromJson<DateTime?>(json['lastUpdateDate']),
       overwriteType: $ProfilesTable.$converteroverwriteType.fromJson(
@@ -463,6 +494,7 @@ class RawProfile extends DataClass implements Insertable<RawProfile> {
       'id': serializer.toJson<int>(id),
       'label': serializer.toJson<String>(label),
       'currentGroupName': serializer.toJson<String?>(currentGroupName),
+      'userAgent': serializer.toJson<String?>(userAgent),
       'url': serializer.toJson<String>(url),
       'lastUpdateDate': serializer.toJson<DateTime?>(lastUpdateDate),
       'overwriteType': serializer.toJson<String>(
@@ -486,6 +518,7 @@ class RawProfile extends DataClass implements Insertable<RawProfile> {
     int? id,
     String? label,
     Value<String?> currentGroupName = const Value.absent(),
+    Value<String?> userAgent = const Value.absent(),
     String? url,
     Value<DateTime?> lastUpdateDate = const Value.absent(),
     OverwriteType? overwriteType,
@@ -502,6 +535,7 @@ class RawProfile extends DataClass implements Insertable<RawProfile> {
     currentGroupName: currentGroupName.present
         ? currentGroupName.value
         : this.currentGroupName,
+    userAgent: userAgent.present ? userAgent.value : this.userAgent,
     url: url ?? this.url,
     lastUpdateDate: lastUpdateDate.present
         ? lastUpdateDate.value
@@ -525,6 +559,7 @@ class RawProfile extends DataClass implements Insertable<RawProfile> {
       currentGroupName: data.currentGroupName.present
           ? data.currentGroupName.value
           : this.currentGroupName,
+      userAgent: data.userAgent.present ? data.userAgent.value : this.userAgent,
       url: data.url.present ? data.url.value : this.url,
       lastUpdateDate: data.lastUpdateDate.present
           ? data.lastUpdateDate.value
@@ -556,6 +591,7 @@ class RawProfile extends DataClass implements Insertable<RawProfile> {
           ..write('id: $id, ')
           ..write('label: $label, ')
           ..write('currentGroupName: $currentGroupName, ')
+          ..write('userAgent: $userAgent, ')
           ..write('url: $url, ')
           ..write('lastUpdateDate: $lastUpdateDate, ')
           ..write('overwriteType: $overwriteType, ')
@@ -575,6 +611,7 @@ class RawProfile extends DataClass implements Insertable<RawProfile> {
     id,
     label,
     currentGroupName,
+    userAgent,
     url,
     lastUpdateDate,
     overwriteType,
@@ -593,6 +630,7 @@ class RawProfile extends DataClass implements Insertable<RawProfile> {
           other.id == this.id &&
           other.label == this.label &&
           other.currentGroupName == this.currentGroupName &&
+          other.userAgent == this.userAgent &&
           other.url == this.url &&
           other.lastUpdateDate == this.lastUpdateDate &&
           other.overwriteType == this.overwriteType &&
@@ -609,6 +647,7 @@ class ProfilesCompanion extends UpdateCompanion<RawProfile> {
   final Value<int> id;
   final Value<String> label;
   final Value<String?> currentGroupName;
+  final Value<String?> userAgent;
   final Value<String> url;
   final Value<DateTime?> lastUpdateDate;
   final Value<OverwriteType> overwriteType;
@@ -623,6 +662,7 @@ class ProfilesCompanion extends UpdateCompanion<RawProfile> {
     this.id = const Value.absent(),
     this.label = const Value.absent(),
     this.currentGroupName = const Value.absent(),
+    this.userAgent = const Value.absent(),
     this.url = const Value.absent(),
     this.lastUpdateDate = const Value.absent(),
     this.overwriteType = const Value.absent(),
@@ -638,6 +678,7 @@ class ProfilesCompanion extends UpdateCompanion<RawProfile> {
     this.id = const Value.absent(),
     required String label,
     this.currentGroupName = const Value.absent(),
+    this.userAgent = const Value.absent(),
     required String url,
     this.lastUpdateDate = const Value.absent(),
     required OverwriteType overwriteType,
@@ -659,6 +700,7 @@ class ProfilesCompanion extends UpdateCompanion<RawProfile> {
     Expression<int>? id,
     Expression<String>? label,
     Expression<String>? currentGroupName,
+    Expression<String>? userAgent,
     Expression<String>? url,
     Expression<DateTime>? lastUpdateDate,
     Expression<String>? overwriteType,
@@ -674,6 +716,7 @@ class ProfilesCompanion extends UpdateCompanion<RawProfile> {
       if (id != null) 'id': id,
       if (label != null) 'label': label,
       if (currentGroupName != null) 'current_group_name': currentGroupName,
+      if (userAgent != null) 'user_agent': userAgent,
       if (url != null) 'url': url,
       if (lastUpdateDate != null) 'last_update_date': lastUpdateDate,
       if (overwriteType != null) 'overwrite_type': overwriteType,
@@ -692,6 +735,7 @@ class ProfilesCompanion extends UpdateCompanion<RawProfile> {
     Value<int>? id,
     Value<String>? label,
     Value<String?>? currentGroupName,
+    Value<String?>? userAgent,
     Value<String>? url,
     Value<DateTime?>? lastUpdateDate,
     Value<OverwriteType>? overwriteType,
@@ -707,6 +751,7 @@ class ProfilesCompanion extends UpdateCompanion<RawProfile> {
       id: id ?? this.id,
       label: label ?? this.label,
       currentGroupName: currentGroupName ?? this.currentGroupName,
+      userAgent: userAgent ?? this.userAgent,
       url: url ?? this.url,
       lastUpdateDate: lastUpdateDate ?? this.lastUpdateDate,
       overwriteType: overwriteType ?? this.overwriteType,
@@ -732,6 +777,9 @@ class ProfilesCompanion extends UpdateCompanion<RawProfile> {
     }
     if (currentGroupName.present) {
       map['current_group_name'] = Variable<String>(currentGroupName.value);
+    }
+    if (userAgent.present) {
+      map['user_agent'] = Variable<String>(userAgent.value);
     }
     if (url.present) {
       map['url'] = Variable<String>(url.value);
@@ -782,6 +830,7 @@ class ProfilesCompanion extends UpdateCompanion<RawProfile> {
           ..write('id: $id, ')
           ..write('label: $label, ')
           ..write('currentGroupName: $currentGroupName, ')
+          ..write('userAgent: $userAgent, ')
           ..write('url: $url, ')
           ..write('lastUpdateDate: $lastUpdateDate, ')
           ..write('overwriteType: $overwriteType, ')
@@ -3470,6 +3519,7 @@ typedef $$ProfilesTableCreateCompanionBuilder =
       Value<int> id,
       required String label,
       Value<String?> currentGroupName,
+      Value<String?> userAgent,
       required String url,
       Value<DateTime?> lastUpdateDate,
       required OverwriteType overwriteType,
@@ -3486,6 +3536,7 @@ typedef $$ProfilesTableUpdateCompanionBuilder =
       Value<int> id,
       Value<String> label,
       Value<String?> currentGroupName,
+      Value<String?> userAgent,
       Value<String> url,
       Value<DateTime?> lastUpdateDate,
       Value<OverwriteType> overwriteType,
@@ -3565,6 +3616,11 @@ class $$ProfilesTableFilterComposer
 
   ColumnFilters<String> get currentGroupName => $composableBuilder(
     column: $table.currentGroupName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get userAgent => $composableBuilder(
+    column: $table.userAgent,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -3701,6 +3757,11 @@ class $$ProfilesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get userAgent => $composableBuilder(
+    column: $table.userAgent,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get url => $composableBuilder(
     column: $table.url,
     builder: (column) => ColumnOrderings(column),
@@ -3771,6 +3832,9 @@ class $$ProfilesTableAnnotationComposer
     column: $table.currentGroupName,
     builder: (column) => column,
   );
+
+  GeneratedColumn<String> get userAgent =>
+      $composableBuilder(column: $table.userAgent, builder: (column) => column);
 
   GeneratedColumn<String> get url =>
       $composableBuilder(column: $table.url, builder: (column) => column);
@@ -3902,6 +3966,7 @@ class $$ProfilesTableTableManager
                 Value<int> id = const Value.absent(),
                 Value<String> label = const Value.absent(),
                 Value<String?> currentGroupName = const Value.absent(),
+                Value<String?> userAgent = const Value.absent(),
                 Value<String> url = const Value.absent(),
                 Value<DateTime?> lastUpdateDate = const Value.absent(),
                 Value<OverwriteType> overwriteType = const Value.absent(),
@@ -3917,6 +3982,7 @@ class $$ProfilesTableTableManager
                 id: id,
                 label: label,
                 currentGroupName: currentGroupName,
+                userAgent: userAgent,
                 url: url,
                 lastUpdateDate: lastUpdateDate,
                 overwriteType: overwriteType,
@@ -3933,6 +3999,7 @@ class $$ProfilesTableTableManager
                 Value<int> id = const Value.absent(),
                 required String label,
                 Value<String?> currentGroupName = const Value.absent(),
+                Value<String?> userAgent = const Value.absent(),
                 required String url,
                 Value<DateTime?> lastUpdateDate = const Value.absent(),
                 required OverwriteType overwriteType,
@@ -3948,6 +4015,7 @@ class $$ProfilesTableTableManager
                 id: id,
                 label: label,
                 currentGroupName: currentGroupName,
+                userAgent: userAgent,
                 url: url,
                 lastUpdateDate: lastUpdateDate,
                 overwriteType: overwriteType,

--- a/lib/database/profiles.dart
+++ b/lib/database/profiles.dart
@@ -11,6 +11,8 @@ class Profiles extends Table {
 
   TextColumn get currentGroupName => text().nullable()();
 
+  TextColumn get userAgent => text().nullable()();
+
   TextColumn get url => text()();
 
   DateTimeColumn get lastUpdateDate => dateTime().nullable()();
@@ -110,6 +112,7 @@ extension RawProfilExt on RawProfile {
       id: id,
       label: label,
       currentGroupName: currentGroupName,
+      userAgent: userAgent,
       url: url,
       lastUpdateDate: lastUpdateDate,
       autoUpdateDuration: Duration(milliseconds: autoUpdateDurationMillis),
@@ -130,6 +133,7 @@ extension ProfilesCompanionExt on Profile {
       id: Value(id),
       label: label,
       currentGroupName: Value(currentGroupName),
+      userAgent: Value(userAgent),
       url: url,
       lastUpdateDate: Value(lastUpdateDate),
       autoUpdateDurationMillis: autoUpdateDuration.inMilliseconds,

--- a/lib/models/generated/profile.freezed.dart
+++ b/lib/models/generated/profile.freezed.dart
@@ -287,7 +287,7 @@ as int,
 /// @nodoc
 mixin _$Profile {
 
- int get id; String get label; String? get currentGroupName; String get url; DateTime? get lastUpdateDate; Duration get autoUpdateDuration; SubscriptionInfo? get subscriptionInfo; bool get autoUpdate; Map<String, String> get selectedMap; Set<String> get unfoldSet; OverwriteType get overwriteType; int? get scriptId; int? get order;
+ int get id; String get label; String? get currentGroupName; String get url; DateTime? get lastUpdateDate; Duration get autoUpdateDuration; String? get userAgent; SubscriptionInfo? get subscriptionInfo; bool get autoUpdate; Map<String, String> get selectedMap; Set<String> get unfoldSet; OverwriteType get overwriteType; int? get scriptId; int? get order;
 /// Create a copy of Profile
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -300,16 +300,16 @@ $ProfileCopyWith<Profile> get copyWith => _$ProfileCopyWithImpl<Profile>(this as
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Profile&&(identical(other.id, id) || other.id == id)&&(identical(other.label, label) || other.label == label)&&(identical(other.currentGroupName, currentGroupName) || other.currentGroupName == currentGroupName)&&(identical(other.url, url) || other.url == url)&&(identical(other.lastUpdateDate, lastUpdateDate) || other.lastUpdateDate == lastUpdateDate)&&(identical(other.autoUpdateDuration, autoUpdateDuration) || other.autoUpdateDuration == autoUpdateDuration)&&(identical(other.subscriptionInfo, subscriptionInfo) || other.subscriptionInfo == subscriptionInfo)&&(identical(other.autoUpdate, autoUpdate) || other.autoUpdate == autoUpdate)&&const DeepCollectionEquality().equals(other.selectedMap, selectedMap)&&const DeepCollectionEquality().equals(other.unfoldSet, unfoldSet)&&(identical(other.overwriteType, overwriteType) || other.overwriteType == overwriteType)&&(identical(other.scriptId, scriptId) || other.scriptId == scriptId)&&(identical(other.order, order) || other.order == order));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Profile&&(identical(other.id, id) || other.id == id)&&(identical(other.label, label) || other.label == label)&&(identical(other.currentGroupName, currentGroupName) || other.currentGroupName == currentGroupName)&&(identical(other.url, url) || other.url == url)&&(identical(other.lastUpdateDate, lastUpdateDate) || other.lastUpdateDate == lastUpdateDate)&&(identical(other.autoUpdateDuration, autoUpdateDuration) || other.autoUpdateDuration == autoUpdateDuration)&&(identical(other.userAgent, userAgent) || other.userAgent == userAgent)&&(identical(other.subscriptionInfo, subscriptionInfo) || other.subscriptionInfo == subscriptionInfo)&&(identical(other.autoUpdate, autoUpdate) || other.autoUpdate == autoUpdate)&&const DeepCollectionEquality().equals(other.selectedMap, selectedMap)&&const DeepCollectionEquality().equals(other.unfoldSet, unfoldSet)&&(identical(other.overwriteType, overwriteType) || other.overwriteType == overwriteType)&&(identical(other.scriptId, scriptId) || other.scriptId == scriptId)&&(identical(other.order, order) || other.order == order));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,label,currentGroupName,url,lastUpdateDate,autoUpdateDuration,subscriptionInfo,autoUpdate,const DeepCollectionEquality().hash(selectedMap),const DeepCollectionEquality().hash(unfoldSet),overwriteType,scriptId,order);
+int get hashCode => Object.hash(runtimeType,id,label,currentGroupName,url,lastUpdateDate,autoUpdateDuration,userAgent,subscriptionInfo,autoUpdate,const DeepCollectionEquality().hash(selectedMap),const DeepCollectionEquality().hash(unfoldSet),overwriteType,scriptId,order);
 
 @override
 String toString() {
-  return 'Profile(id: $id, label: $label, currentGroupName: $currentGroupName, url: $url, lastUpdateDate: $lastUpdateDate, autoUpdateDuration: $autoUpdateDuration, subscriptionInfo: $subscriptionInfo, autoUpdate: $autoUpdate, selectedMap: $selectedMap, unfoldSet: $unfoldSet, overwriteType: $overwriteType, scriptId: $scriptId, order: $order)';
+  return 'Profile(id: $id, label: $label, currentGroupName: $currentGroupName, url: $url, lastUpdateDate: $lastUpdateDate, autoUpdateDuration: $autoUpdateDuration, userAgent: $userAgent, subscriptionInfo: $subscriptionInfo, autoUpdate: $autoUpdate, selectedMap: $selectedMap, unfoldSet: $unfoldSet, overwriteType: $overwriteType, scriptId: $scriptId, order: $order)';
 }
 
 
@@ -320,7 +320,7 @@ abstract mixin class $ProfileCopyWith<$Res>  {
   factory $ProfileCopyWith(Profile value, $Res Function(Profile) _then) = _$ProfileCopyWithImpl;
 @useResult
 $Res call({
- int id, String label, String? currentGroupName, String url, DateTime? lastUpdateDate, Duration autoUpdateDuration, SubscriptionInfo? subscriptionInfo, bool autoUpdate, Map<String, String> selectedMap, Set<String> unfoldSet, OverwriteType overwriteType, int? scriptId, int? order
+ int id, String label, String? currentGroupName, String url, DateTime? lastUpdateDate, Duration autoUpdateDuration, String? userAgent, SubscriptionInfo? subscriptionInfo, bool autoUpdate, Map<String, String> selectedMap, Set<String> unfoldSet, OverwriteType overwriteType, int? scriptId, int? order
 });
 
 
@@ -337,7 +337,7 @@ class _$ProfileCopyWithImpl<$Res>
 
 /// Create a copy of Profile
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? label = null,Object? currentGroupName = freezed,Object? url = null,Object? lastUpdateDate = freezed,Object? autoUpdateDuration = null,Object? subscriptionInfo = freezed,Object? autoUpdate = null,Object? selectedMap = null,Object? unfoldSet = null,Object? overwriteType = null,Object? scriptId = freezed,Object? order = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? label = null,Object? currentGroupName = freezed,Object? url = null,Object? lastUpdateDate = freezed,Object? autoUpdateDuration = null,Object? userAgent = freezed,Object? subscriptionInfo = freezed,Object? autoUpdate = null,Object? selectedMap = null,Object? unfoldSet = null,Object? overwriteType = null,Object? scriptId = freezed,Object? order = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
@@ -345,7 +345,8 @@ as String,currentGroupName: freezed == currentGroupName ? _self.currentGroupName
 as String?,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
 as String,lastUpdateDate: freezed == lastUpdateDate ? _self.lastUpdateDate : lastUpdateDate // ignore: cast_nullable_to_non_nullable
 as DateTime?,autoUpdateDuration: null == autoUpdateDuration ? _self.autoUpdateDuration : autoUpdateDuration // ignore: cast_nullable_to_non_nullable
-as Duration,subscriptionInfo: freezed == subscriptionInfo ? _self.subscriptionInfo : subscriptionInfo // ignore: cast_nullable_to_non_nullable
+as Duration,userAgent: freezed == userAgent ? _self.userAgent : userAgent // ignore: cast_nullable_to_non_nullable
+as String?,subscriptionInfo: freezed == subscriptionInfo ? _self.subscriptionInfo : subscriptionInfo // ignore: cast_nullable_to_non_nullable
 as SubscriptionInfo?,autoUpdate: null == autoUpdate ? _self.autoUpdate : autoUpdate // ignore: cast_nullable_to_non_nullable
 as bool,selectedMap: null == selectedMap ? _self.selectedMap : selectedMap // ignore: cast_nullable_to_non_nullable
 as Map<String, String>,unfoldSet: null == unfoldSet ? _self.unfoldSet : unfoldSet // ignore: cast_nullable_to_non_nullable
@@ -449,10 +450,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String label,  String? currentGroupName,  String url,  DateTime? lastUpdateDate,  Duration autoUpdateDuration,  SubscriptionInfo? subscriptionInfo,  bool autoUpdate,  Map<String, String> selectedMap,  Set<String> unfoldSet,  OverwriteType overwriteType,  int? scriptId,  int? order)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String label,  String? currentGroupName,  String url,  DateTime? lastUpdateDate,  Duration autoUpdateDuration,  String? userAgent,  SubscriptionInfo? subscriptionInfo,  bool autoUpdate,  Map<String, String> selectedMap,  Set<String> unfoldSet,  OverwriteType overwriteType,  int? scriptId,  int? order)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Profile() when $default != null:
-return $default(_that.id,_that.label,_that.currentGroupName,_that.url,_that.lastUpdateDate,_that.autoUpdateDuration,_that.subscriptionInfo,_that.autoUpdate,_that.selectedMap,_that.unfoldSet,_that.overwriteType,_that.scriptId,_that.order);case _:
+return $default(_that.id,_that.label,_that.currentGroupName,_that.url,_that.lastUpdateDate,_that.autoUpdateDuration,_that.userAgent,_that.subscriptionInfo,_that.autoUpdate,_that.selectedMap,_that.unfoldSet,_that.overwriteType,_that.scriptId,_that.order);case _:
   return orElse();
 
 }
@@ -470,10 +471,10 @@ return $default(_that.id,_that.label,_that.currentGroupName,_that.url,_that.last
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String label,  String? currentGroupName,  String url,  DateTime? lastUpdateDate,  Duration autoUpdateDuration,  SubscriptionInfo? subscriptionInfo,  bool autoUpdate,  Map<String, String> selectedMap,  Set<String> unfoldSet,  OverwriteType overwriteType,  int? scriptId,  int? order)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String label,  String? currentGroupName,  String url,  DateTime? lastUpdateDate,  Duration autoUpdateDuration,  String? userAgent,  SubscriptionInfo? subscriptionInfo,  bool autoUpdate,  Map<String, String> selectedMap,  Set<String> unfoldSet,  OverwriteType overwriteType,  int? scriptId,  int? order)  $default,) {final _that = this;
 switch (_that) {
 case _Profile():
-return $default(_that.id,_that.label,_that.currentGroupName,_that.url,_that.lastUpdateDate,_that.autoUpdateDuration,_that.subscriptionInfo,_that.autoUpdate,_that.selectedMap,_that.unfoldSet,_that.overwriteType,_that.scriptId,_that.order);case _:
+return $default(_that.id,_that.label,_that.currentGroupName,_that.url,_that.lastUpdateDate,_that.autoUpdateDuration,_that.userAgent,_that.subscriptionInfo,_that.autoUpdate,_that.selectedMap,_that.unfoldSet,_that.overwriteType,_that.scriptId,_that.order);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -490,10 +491,10 @@ return $default(_that.id,_that.label,_that.currentGroupName,_that.url,_that.last
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String label,  String? currentGroupName,  String url,  DateTime? lastUpdateDate,  Duration autoUpdateDuration,  SubscriptionInfo? subscriptionInfo,  bool autoUpdate,  Map<String, String> selectedMap,  Set<String> unfoldSet,  OverwriteType overwriteType,  int? scriptId,  int? order)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String label,  String? currentGroupName,  String url,  DateTime? lastUpdateDate,  Duration autoUpdateDuration,  String? userAgent,  SubscriptionInfo? subscriptionInfo,  bool autoUpdate,  Map<String, String> selectedMap,  Set<String> unfoldSet,  OverwriteType overwriteType,  int? scriptId,  int? order)?  $default,) {final _that = this;
 switch (_that) {
 case _Profile() when $default != null:
-return $default(_that.id,_that.label,_that.currentGroupName,_that.url,_that.lastUpdateDate,_that.autoUpdateDuration,_that.subscriptionInfo,_that.autoUpdate,_that.selectedMap,_that.unfoldSet,_that.overwriteType,_that.scriptId,_that.order);case _:
+return $default(_that.id,_that.label,_that.currentGroupName,_that.url,_that.lastUpdateDate,_that.autoUpdateDuration,_that.userAgent,_that.subscriptionInfo,_that.autoUpdate,_that.selectedMap,_that.unfoldSet,_that.overwriteType,_that.scriptId,_that.order);case _:
   return null;
 
 }
@@ -505,7 +506,7 @@ return $default(_that.id,_that.label,_that.currentGroupName,_that.url,_that.last
 @JsonSerializable()
 
 class _Profile implements Profile {
-  const _Profile({required this.id, this.label = '', this.currentGroupName, this.url = '', this.lastUpdateDate, required this.autoUpdateDuration, this.subscriptionInfo, this.autoUpdate = true, final  Map<String, String> selectedMap = const {}, final  Set<String> unfoldSet = const {}, this.overwriteType = OverwriteType.standard, this.scriptId, this.order}): _selectedMap = selectedMap,_unfoldSet = unfoldSet;
+  const _Profile({required this.id, this.label = '', this.currentGroupName, this.url = '', this.lastUpdateDate, required this.autoUpdateDuration, this.userAgent = null, this.subscriptionInfo, this.autoUpdate = true, final  Map<String, String> selectedMap = const {}, final  Set<String> unfoldSet = const {}, this.overwriteType = OverwriteType.standard, this.scriptId, this.order}): _selectedMap = selectedMap,_unfoldSet = unfoldSet;
   factory _Profile.fromJson(Map<String, dynamic> json) => _$ProfileFromJson(json);
 
 @override final  int id;
@@ -514,6 +515,7 @@ class _Profile implements Profile {
 @override@JsonKey() final  String url;
 @override final  DateTime? lastUpdateDate;
 @override final  Duration autoUpdateDuration;
+@override@JsonKey() final  String? userAgent;
 @override final  SubscriptionInfo? subscriptionInfo;
 @override@JsonKey() final  bool autoUpdate;
  final  Map<String, String> _selectedMap;
@@ -547,16 +549,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Profile&&(identical(other.id, id) || other.id == id)&&(identical(other.label, label) || other.label == label)&&(identical(other.currentGroupName, currentGroupName) || other.currentGroupName == currentGroupName)&&(identical(other.url, url) || other.url == url)&&(identical(other.lastUpdateDate, lastUpdateDate) || other.lastUpdateDate == lastUpdateDate)&&(identical(other.autoUpdateDuration, autoUpdateDuration) || other.autoUpdateDuration == autoUpdateDuration)&&(identical(other.subscriptionInfo, subscriptionInfo) || other.subscriptionInfo == subscriptionInfo)&&(identical(other.autoUpdate, autoUpdate) || other.autoUpdate == autoUpdate)&&const DeepCollectionEquality().equals(other._selectedMap, _selectedMap)&&const DeepCollectionEquality().equals(other._unfoldSet, _unfoldSet)&&(identical(other.overwriteType, overwriteType) || other.overwriteType == overwriteType)&&(identical(other.scriptId, scriptId) || other.scriptId == scriptId)&&(identical(other.order, order) || other.order == order));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Profile&&(identical(other.id, id) || other.id == id)&&(identical(other.label, label) || other.label == label)&&(identical(other.currentGroupName, currentGroupName) || other.currentGroupName == currentGroupName)&&(identical(other.url, url) || other.url == url)&&(identical(other.lastUpdateDate, lastUpdateDate) || other.lastUpdateDate == lastUpdateDate)&&(identical(other.autoUpdateDuration, autoUpdateDuration) || other.autoUpdateDuration == autoUpdateDuration)&&(identical(other.userAgent, userAgent) || other.userAgent == userAgent)&&(identical(other.subscriptionInfo, subscriptionInfo) || other.subscriptionInfo == subscriptionInfo)&&(identical(other.autoUpdate, autoUpdate) || other.autoUpdate == autoUpdate)&&const DeepCollectionEquality().equals(other._selectedMap, _selectedMap)&&const DeepCollectionEquality().equals(other._unfoldSet, _unfoldSet)&&(identical(other.overwriteType, overwriteType) || other.overwriteType == overwriteType)&&(identical(other.scriptId, scriptId) || other.scriptId == scriptId)&&(identical(other.order, order) || other.order == order));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,label,currentGroupName,url,lastUpdateDate,autoUpdateDuration,subscriptionInfo,autoUpdate,const DeepCollectionEquality().hash(_selectedMap),const DeepCollectionEquality().hash(_unfoldSet),overwriteType,scriptId,order);
+int get hashCode => Object.hash(runtimeType,id,label,currentGroupName,url,lastUpdateDate,autoUpdateDuration,userAgent,subscriptionInfo,autoUpdate,const DeepCollectionEquality().hash(_selectedMap),const DeepCollectionEquality().hash(_unfoldSet),overwriteType,scriptId,order);
 
 @override
 String toString() {
-  return 'Profile(id: $id, label: $label, currentGroupName: $currentGroupName, url: $url, lastUpdateDate: $lastUpdateDate, autoUpdateDuration: $autoUpdateDuration, subscriptionInfo: $subscriptionInfo, autoUpdate: $autoUpdate, selectedMap: $selectedMap, unfoldSet: $unfoldSet, overwriteType: $overwriteType, scriptId: $scriptId, order: $order)';
+  return 'Profile(id: $id, label: $label, currentGroupName: $currentGroupName, url: $url, lastUpdateDate: $lastUpdateDate, autoUpdateDuration: $autoUpdateDuration, userAgent: $userAgent, subscriptionInfo: $subscriptionInfo, autoUpdate: $autoUpdate, selectedMap: $selectedMap, unfoldSet: $unfoldSet, overwriteType: $overwriteType, scriptId: $scriptId, order: $order)';
 }
 
 
@@ -567,7 +569,7 @@ abstract mixin class _$ProfileCopyWith<$Res> implements $ProfileCopyWith<$Res> {
   factory _$ProfileCopyWith(_Profile value, $Res Function(_Profile) _then) = __$ProfileCopyWithImpl;
 @override @useResult
 $Res call({
- int id, String label, String? currentGroupName, String url, DateTime? lastUpdateDate, Duration autoUpdateDuration, SubscriptionInfo? subscriptionInfo, bool autoUpdate, Map<String, String> selectedMap, Set<String> unfoldSet, OverwriteType overwriteType, int? scriptId, int? order
+ int id, String label, String? currentGroupName, String url, DateTime? lastUpdateDate, Duration autoUpdateDuration, String? userAgent, SubscriptionInfo? subscriptionInfo, bool autoUpdate, Map<String, String> selectedMap, Set<String> unfoldSet, OverwriteType overwriteType, int? scriptId, int? order
 });
 
 
@@ -584,7 +586,7 @@ class __$ProfileCopyWithImpl<$Res>
 
 /// Create a copy of Profile
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? label = null,Object? currentGroupName = freezed,Object? url = null,Object? lastUpdateDate = freezed,Object? autoUpdateDuration = null,Object? subscriptionInfo = freezed,Object? autoUpdate = null,Object? selectedMap = null,Object? unfoldSet = null,Object? overwriteType = null,Object? scriptId = freezed,Object? order = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? label = null,Object? currentGroupName = freezed,Object? url = null,Object? lastUpdateDate = freezed,Object? autoUpdateDuration = null,Object? userAgent = freezed,Object? subscriptionInfo = freezed,Object? autoUpdate = null,Object? selectedMap = null,Object? unfoldSet = null,Object? overwriteType = null,Object? scriptId = freezed,Object? order = freezed,}) {
   return _then(_Profile(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
@@ -592,7 +594,8 @@ as String,currentGroupName: freezed == currentGroupName ? _self.currentGroupName
 as String?,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
 as String,lastUpdateDate: freezed == lastUpdateDate ? _self.lastUpdateDate : lastUpdateDate // ignore: cast_nullable_to_non_nullable
 as DateTime?,autoUpdateDuration: null == autoUpdateDuration ? _self.autoUpdateDuration : autoUpdateDuration // ignore: cast_nullable_to_non_nullable
-as Duration,subscriptionInfo: freezed == subscriptionInfo ? _self.subscriptionInfo : subscriptionInfo // ignore: cast_nullable_to_non_nullable
+as Duration,userAgent: freezed == userAgent ? _self.userAgent : userAgent // ignore: cast_nullable_to_non_nullable
+as String?,subscriptionInfo: freezed == subscriptionInfo ? _self.subscriptionInfo : subscriptionInfo // ignore: cast_nullable_to_non_nullable
 as SubscriptionInfo?,autoUpdate: null == autoUpdate ? _self.autoUpdate : autoUpdate // ignore: cast_nullable_to_non_nullable
 as bool,selectedMap: null == selectedMap ? _self._selectedMap : selectedMap // ignore: cast_nullable_to_non_nullable
 as Map<String, String>,unfoldSet: null == unfoldSet ? _self._unfoldSet : unfoldSet // ignore: cast_nullable_to_non_nullable

--- a/lib/models/generated/profile.g.dart
+++ b/lib/models/generated/profile.g.dart
@@ -33,6 +33,7 @@ _Profile _$ProfileFromJson(Map<String, dynamic> json) => _Profile(
   autoUpdateDuration: Duration(
     microseconds: (json['autoUpdateDuration'] as num).toInt(),
   ),
+  userAgent: json['userAgent'] as String? ?? null,
   subscriptionInfo: json['subscriptionInfo'] == null
       ? null
       : SubscriptionInfo.fromJson(
@@ -61,6 +62,7 @@ Map<String, dynamic> _$ProfileToJson(_Profile instance) => <String, dynamic>{
   'url': instance.url,
   'lastUpdateDate': instance.lastUpdateDate?.toIso8601String(),
   'autoUpdateDuration': instance.autoUpdateDuration.inMicroseconds,
+  'userAgent': instance.userAgent,
   'subscriptionInfo': instance.subscriptionInfo,
   'autoUpdate': instance.autoUpdate,
   'selectedMap': instance.selectedMap,

--- a/lib/models/profile.dart
+++ b/lib/models/profile.dart
@@ -49,6 +49,7 @@ abstract class Profile with _$Profile {
     @Default('') String url,
     DateTime? lastUpdateDate,
     required Duration autoUpdateDuration,
+    @Default(null) String? userAgent,
     SubscriptionInfo? subscriptionInfo,
     @Default(true) bool autoUpdate,
     @Default({}) Map<String, String> selectedMap,
@@ -198,7 +199,7 @@ extension ProfileExtension on Profile {
   }
 
   Future<Profile> update() async {
-    final response = await request.getFileResponseForUrl(url);
+    final response = await request.getFileResponseForUrl(url, userAgent: userAgent);
     final disposition = response.headers.value('content-disposition');
     final userinfo = response.headers.value('subscription-userinfo');
     return copyWith(

--- a/lib/pages/scan.dart
+++ b/lib/pages/scan.dart
@@ -140,9 +140,14 @@ class _ScanPageState extends State<ScanPage> with WidgetsBindingObserver {
               ),
               padding: const EdgeInsets.all(16),
               iconSize: 32.0,
-              onPressed: globalState.container
-                  .read(profilesActionProvider.notifier)
-                  .addProfileFormQrCode,
+              onPressed: () async {
+                final url = await globalState.container
+                    .read(profilesActionProvider.notifier)
+                    .getQrCodeUrl();
+                if (url != null && context.mounted) {
+                  Navigator.pop(context, url);
+                }
+              },
               icon: const Icon(Icons.photo_camera_back),
             ),
           ),

--- a/lib/providers/action.dart
+++ b/lib/providers/action.dart
@@ -926,7 +926,7 @@ class ProfilesAction extends _$ProfilesAction {
     }
   }
 
-  Future<void> addProfileFormURL(String url) async {
+  Future<void> addProfileFormURL(String url, {String? userAgent}) async {
     if (globalState.navigatorKey.currentState?.canPop() ?? false) {
       globalState.navigatorKey.currentState?.popUntil((route) => route.isFirst);
     }
@@ -934,7 +934,7 @@ class ProfilesAction extends _$ProfilesAction {
     final profile = await globalState.loadingRun(
       tag: LoadingTag.profiles,
       () async {
-        return Profile.normal(url: url).update();
+        return Profile.normal(url: url).copyWith(userAgent: userAgent).update();
       },
       title: currentAppLocalizations.addProfile,
     );
@@ -950,10 +950,9 @@ class ProfilesAction extends _$ProfilesAction {
     }
   }
 
-  Future<void> addProfileFormQrCode() async {
+  Future<String?> getQrCodeUrl() async {
     final url = await globalState.safeRun(picker.pickerConfigQRCode);
-    if (url == null) return;
-    addProfileFormURL(url);
+    return url;
   }
 
   void reorder(List<Profile> profiles) {

--- a/lib/providers/generated/action.g.dart
+++ b/lib/providers/generated/action.g.dart
@@ -91,7 +91,7 @@ final class SetupActionProvider extends $NotifierProvider<SetupAction, void> {
   }
 }
 
-String _$setupActionHash() => r'5e7aff49668e1013e2024c452b08950ccf2472fe';
+String _$setupActionHash() => r'e4b4e963be3e36b441ce5f4dc741e7650f7b2fee';
 
 abstract class _$SetupAction extends $Notifier<void> {
   void build();
@@ -450,7 +450,7 @@ final class ProfilesActionProvider
   }
 }
 
-String _$profilesActionHash() => r'5c4a52394a97ff40cb9bc7bf30d7a412e36e877a';
+String _$profilesActionHash() => r'fc83aef5da45e5335344f6cd3ab71e2b9335fc58';
 
 abstract class _$ProfilesAction extends $Notifier<void> {
   void build();

--- a/lib/providers/generated/app.g.dart
+++ b/lib/providers/generated/app.g.dart
@@ -1791,7 +1791,7 @@ final class NetworkDetectionProvider
   }
 }
 
-String _$networkDetectionHash() => r'e2892c87c76992bec307699de7d838152aa272d5';
+String _$networkDetectionHash() => r'1cab20d67ec54321b4dbba9d971cd80e98542e23';
 
 abstract class _$NetworkDetection extends $Notifier<NetworkDetectionState> {
   NetworkDetectionState build();

--- a/lib/providers/generated/database.g.dart
+++ b/lib/providers/generated/database.g.dart
@@ -292,7 +292,7 @@ final class ProfilesProvider
   }
 }
 
-String _$profilesHash() => r'a37c94a2b4f8c9aabb25e1c90b22a760507611f8';
+String _$profilesHash() => r'a977548501ae750bc4fcc0f59dc0a4994ced7c91';
 
 abstract class _$Profiles extends $Notifier<List<Profile>> {
   List<Profile> build();
@@ -336,7 +336,7 @@ final class ScriptsProvider
   Scripts create() => Scripts();
 }
 
-String _$scriptsHash() => r'c5c3c1a4529be6e13a9516ca0b6f98a2e0e127b4';
+String _$scriptsHash() => r'363611e5787ec107459446f305e35dada3e07cad';
 
 abstract class _$Scripts extends $StreamNotifier<List<Script>> {
   Stream<List<Script>> build();
@@ -449,7 +449,7 @@ final class GlobalRulesProvider
   GlobalRules create() => GlobalRules();
 }
 
-String _$globalRulesHash() => r'fcded4e1dc862ac0ddd3223df9b723072d6f2fd5';
+String _$globalRulesHash() => r'62b73e41ec09eb2f4b7180ada83016c89a9b1ed7';
 
 abstract class _$GlobalRules extends $StreamNotifier<List<Rule>> {
   Stream<List<Rule>> build();
@@ -510,7 +510,7 @@ final class ProfileAddedRulesProvider
   }
 }
 
-String _$profileAddedRulesHash() => r'276c520db54aec72ade2544260f26a43cbb71960';
+String _$profileAddedRulesHash() => r'8cfcd70305b59dc083c0636a0a121411bdd48864';
 
 final class ProfileAddedRulesFamily extends $Family
     with
@@ -600,7 +600,7 @@ final class ProfileCustomRulesProvider
 }
 
 String _$profileCustomRulesHash() =>
-    r'3f4871fe309c1525ae65699eb1eb5fbcb1474acd';
+    r'ff60ec05732c7eeaea636af2ca35022477cf9e8a';
 
 final class ProfileCustomRulesFamily extends $Family
     with
@@ -689,7 +689,7 @@ final class ProxyGroupsProvider
   }
 }
 
-String _$proxyGroupsHash() => r'ea6abec14f31cf0fd8e74b5ba81c1625b3a705c3';
+String _$proxyGroupsHash() => r'f0435528c3828d2aa51a900e79b1631dc9b2c893';
 
 final class ProxyGroupsFamily extends $Family
     with
@@ -781,7 +781,7 @@ final class ProfileDisabledRuleIdsProvider
 }
 
 String _$profileDisabledRuleIdsHash() =>
-    r'595f81356a549fb4438ac5796df8b26a0c3e5e5d';
+    r'8fdd7dc5c5ff51e7d9474c0351887073e3f8d468';
 
 final class ProfileDisabledRuleIdsFamily extends $Family
     with

--- a/lib/providers/generated/state.g.dart
+++ b/lib/providers/generated/state.g.dart
@@ -228,7 +228,7 @@ final class ProxyStateProvider
   }
 }
 
-String _$proxyStateHash() => r'3df11daa70bd06de32da43e9b3e09a74389264b2';
+String _$proxyStateHash() => r'b4a316e7f67927d6903af702d2b4e542c11c11c8';
 
 @ProviderFor(trayState)
 final trayStateProvider = TrayStateProvider._();

--- a/lib/views/config/general.dart
+++ b/lib/views/config/general.dart
@@ -47,20 +47,236 @@ class UaItem extends ConsumerWidget {
     final globalUa = ref.watch(
       patchClashConfigProvider.select((state) => state.globalUa),
     );
-    return ListItem<String?>.options(
+    return ListItem(
       leading: const Icon(Icons.computer_outlined),
       title: const Text('UA'),
-      subtitle: Text(globalUa ?? appLocalizations.defaultText),
-      delegate: OptionsDelegate<String?>(
-        title: 'UA',
-        options: [null, 'clash-verge/v2.4.2', 'ClashforWindows/0.19.23'],
-        value: globalUa,
-        onChanged: (value) {
-          ref
-              .read(patchClashConfigProvider.notifier)
-              .update((state) => state.copyWith(globalUa: value));
-        },
-        textBuilder: (ua) => ua ?? appLocalizations.defaultText,
+      subtitle: Text(
+        globalUa ?? appLocalizations.defaultText,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      onTap: () async {
+        // Use UaResult wrapper to distinguish "cancelled" from "selected Default"
+        final result = await globalState.showCommonDialog<UaResult>(
+          child: UaDialog(currentUa: globalUa),
+        );
+        if (result == null) return;
+        ref
+            .read(patchClashConfigProvider.notifier)
+            .update((state) => state.copyWith(globalUa: result.value));
+      },
+    );
+  }
+}
+
+/// Wrapper to distinguish "dialog cancelled" (null) from "user chose Default" (UaResult).
+class UaResult {
+  final String? value;
+  const UaResult(this.value);
+}
+
+class UaDialog extends StatefulWidget {
+  final String? currentUa;
+  final String defaultLabel;
+  final String? title;
+
+  const UaDialog({
+    super.key,
+    this.title,
+    required this.currentUa,
+    this.defaultLabel = 'Default',
+  });
+
+  @override
+  State<UaDialog> createState() => UaDialogState();
+}
+
+class UaDialogState extends State<UaDialog> {
+  late final List<(String?, String)> _presetUas = [
+    (null, widget.defaultLabel),
+    ('', 'Default'),
+    ('clash-verge/v2.4.2', 'clash-verge'),
+    ('ClashforWindows/0.19.23', 'Clash for Windows'),
+    (
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+      'Chrome 131 (Windows)',
+    ),
+    (
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0',
+      'Firefox 133 (Windows)',
+    ),
+    (
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15',
+      'Safari 17 (macOS)',
+    ),
+    (
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0',
+      'Edge 131 (Windows)',
+    ),
+    (
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 OPR/116.0.0.0',
+      'Opera 116 (Windows)',
+    ),
+    (
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1',
+      'Safari (iOS)',
+    ),
+    (
+      'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36',
+      'Chrome (Android)',
+    ),
+  ];
+
+  static const _customKey = '__custom__';
+
+  late String? _selectedValue;
+  late TextEditingController _customController;
+  bool _isCustom = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedValue = widget.currentUa;
+    _customController = TextEditingController(
+      text: widget.currentUa ?? '',
+    );
+    // If current value is not one of the presets, treat it as custom
+    final isPreset = _presetUas.any((pair) => pair.$1 == widget.currentUa);
+    _isCustom = widget.currentUa != null && !isPreset;
+  }
+
+  @override
+  void dispose() {
+    _customController.dispose();
+    super.dispose();
+  }
+
+  void _handlePresetSelected(String? value) {
+    setState(() {
+      _selectedValue = value;
+      _isCustom = false;
+    });
+  }
+
+  void _handleCustomSelected() {
+    setState(() {
+      _isCustom = true;
+      _selectedValue = _customController.text.isEmpty
+          ? null
+          : _customController.text;
+    });
+  }
+
+  void _handleCustomChanged(String value) {
+    setState(() {
+      _selectedValue = value.isEmpty ? null : value;
+    });
+  }
+
+  void _handleSubmit() {
+    final value = _isCustom
+        ? _customController.text.trim()
+        : _selectedValue;
+    Navigator.of(context).pop<UaResult>(UaResult(value));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = context.appLocalizations;
+    return CommonDialog(
+      title: widget.title ?? 'UA',
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: Text(appLocalizations.cancel),
+        ),
+        TextButton(
+          onPressed: _handleSubmit,
+          child: Text(appLocalizations.submit),
+        ),
+      ],
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Preset radio options
+          RadioGroup<String?>(
+            groupValue: _isCustom ? _customKey : _selectedValue,
+            onChanged: (value) {
+              if (value == _customKey) {
+                _handleCustomSelected();
+              } else {
+                _handlePresetSelected(value);
+              }
+            },
+            child: Wrap(
+              children: [
+                for (final (uaValue, label) in _presetUas)
+                  Builder(
+                    builder: (context) {
+                      final isSelected =
+                          !_isCustom && _selectedValue == uaValue;
+                      if (isSelected) {
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          Scrollable.ensureVisible(context);
+                        });
+                      }
+                      return ListItem.radio(
+                        delegate: RadioDelegate<String?>(
+                          value: uaValue,
+                          onTab: () {
+                            _handlePresetSelected(uaValue);
+                          },
+                        ),
+                        title: Text(label),
+                      );
+                    },
+                  ),
+                // Custom option
+                Builder(
+                  builder: (context) {
+                    if (_isCustom) {
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        Scrollable.ensureVisible(context);
+                      });
+                    }
+                    return ListItem.radio(
+                      delegate: RadioDelegate<String?>(
+                        value: _customKey,
+                        onTab: () {
+                          _handleCustomSelected();
+                        },
+                      ),
+                      title: Text(appLocalizations.custom),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+          // Custom UA text input
+          if (_isCustom) ...[
+            const Divider(height: 16),
+            TextField(
+              controller: _customController,
+              autofocus: true,
+              maxLines: 3,
+              minLines: 1,
+              keyboardType: TextInputType.text,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                hintText: 'Mozilla/5.0 ...',
+                labelText: 'User-Agent',
+              ),
+              onChanged: _handleCustomChanged,
+              onSubmitted: (_) {
+                _handleSubmit();
+              },
+            ),
+          ],
+        ],
       ),
     );
   }

--- a/lib/views/profiles/add.dart
+++ b/lib/views/profiles/add.dart
@@ -1,4 +1,5 @@
 import 'package:fl_clash/common/common.dart';
+import 'package:fl_clash/views/config/general.dart';
 import 'package:fl_clash/pages/scan.dart';
 import 'package:fl_clash/providers/action.dart';
 import 'package:fl_clash/state.dart';
@@ -16,48 +17,31 @@ class AddProfileView extends StatelessWidget {
         .addProfileFormFile();
   }
 
-  Future<void> _handleAddProfileFormURL(String url) async {
-    globalState.container
-        .read(profilesActionProvider.notifier)
-        .addProfileFormURL(url);
-  }
 
   Future<void> _toScan() async {
     if (system.isDesktop) {
-      globalState.container
-          .read(profilesActionProvider.notifier)
-          .addProfileFormQrCode();
+      final url = await globalState.safeRun(picker.pickerConfigQRCode);
+      if (url != null) {
+        _toAdd(url);
+      }
       return;
     }
     final url = await BaseNavigator.push(context, const ScanPage());
     if (url != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        _handleAddProfileFormURL(url);
+        _toAdd(url);
       });
     }
   }
 
-  Future<void> _toAdd() async {
-    final appLocalizations = context.appLocalizations;
-    final url = await globalState.showCommonDialog<String>(
-      child: InputDialog(
-        autovalidateMode: AutovalidateMode.onUnfocus,
-        title: appLocalizations.importFromURL,
-        labelText: appLocalizations.url,
-        value: '',
-        validator: (value) {
-          if (value == null || value.isEmpty) {
-            return appLocalizations.emptyTip('').trim();
-          }
-          if (!value.isUrl) {
-            return appLocalizations.urlTip('').trim();
-          }
-          return null;
-        },
-      ),
+  Future<void> _toAdd([String? initialUrl]) async {
+    final res = await globalState.showCommonDialog<(String, String?)>(
+      child: URLFormDialog(initialUrl: initialUrl ?? ''),
     );
-    if (url != null) {
-      _handleAddProfileFormURL(url);
+    if (res != null) {
+      globalState.container
+          .read(profilesActionProvider.notifier)
+          .addProfileFormURL(res.$1, userAgent: res.$2);
     }
   }
 
@@ -90,19 +74,21 @@ class AddProfileView extends StatelessWidget {
 }
 
 class URLFormDialog extends StatefulWidget {
-  const URLFormDialog({super.key});
+  final String initialUrl;
+  const URLFormDialog({super.key, this.initialUrl = ''});
 
   @override
   State<URLFormDialog> createState() => _URLFormDialogState();
 }
 
 class _URLFormDialogState extends State<URLFormDialog> {
-  final _urlController = TextEditingController();
+  late final _urlController = TextEditingController(text: widget.initialUrl);
+  String? _userAgent;
 
   Future<void> _handleAddProfileFormURL() async {
     final url = _urlController.value.text;
     if (url.isEmpty) return;
-    Navigator.of(context).pop<String>(url);
+    Navigator.of(context).pop<(String, String?)>((url, _userAgent));
   }
 
   @override
@@ -140,6 +126,33 @@ class _URLFormDialogState extends State<URLFormDialog> {
                 border: const OutlineInputBorder(),
                 labelText: appLocalizations.url,
               ),
+            ),
+            ListItem(
+              title: const Text('User-Agent'),
+              subtitle: Padding(
+                padding: const EdgeInsets.only(top: 8.0),
+                child: Text(
+                  _userAgent ?? 'Global',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                ),
+              ),
+              onTap: () async {
+                final result = await globalState.showCommonDialog<UaResult>(
+                  child: UaDialog(
+                    title: 'UA',
+                    currentUa: _userAgent,
+                    defaultLabel: 'Global',
+                  ),
+                );
+                if (result == null) return;
+                setState(() {
+                  _userAgent = result.value;
+                });
+              },
             ),
           ],
         ),

--- a/lib/views/profiles/edit.dart
+++ b/lib/views/profiles/edit.dart
@@ -9,6 +9,7 @@ import 'package:fl_clash/models/models.dart';
 import 'package:fl_clash/pages/editor.dart';
 import 'package:fl_clash/providers/action.dart';
 import 'package:fl_clash/state.dart';
+import 'package:fl_clash/views/config/general.dart';
 import 'package:fl_clash/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 
@@ -32,6 +33,7 @@ class _EditProfileViewState extends State<EditProfileView> {
   late final TextEditingController _autoUpdateDurationController;
   late bool _autoUpdate;
   String? _rawText;
+  String? _userAgent;
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final _fileInfoNotifier = ValueNotifier<FileInfo?>(null);
   Uint8List? _fileData;
@@ -42,6 +44,7 @@ class _EditProfileViewState extends State<EditProfileView> {
     _labelController = TextEditingController(text: widget.profile.label);
     _urlController = TextEditingController(text: widget.profile.url);
     _autoUpdate = widget.profile.autoUpdate;
+    _userAgent = widget.profile.userAgent;
     _autoUpdateDurationController = TextEditingController(
       text: widget.profile.autoUpdateDuration.inMinutes.toString(),
     );
@@ -67,6 +70,7 @@ class _EditProfileViewState extends State<EditProfileView> {
       url: _urlController.text,
       label: _labelController.text,
       autoUpdate: _autoUpdate,
+      userAgent: _userAgent,
       autoUpdateDuration: Duration(
         minutes: int.parse(_autoUpdateDurationController.text),
       ),
@@ -286,6 +290,33 @@ class _EditProfileViewState extends State<EditProfileView> {
               },
             ),
           ),
+        ListItem(
+          title: const Text('User-Agent'),
+          subtitle: Padding(
+            padding: const EdgeInsets.only(top: 8.0),
+            child: Text(
+              _userAgent ?? 'Global',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ),
+          onTap: () async {
+            final result = await globalState.showCommonDialog<UaResult>(
+              child: UaDialog(
+                title: 'UA - ${widget.profile.label}',
+                currentUa: _userAgent,
+                defaultLabel: 'Global',
+              ),
+            );
+            if (result == null) return;
+            setState(() {
+              _userAgent = result.value;
+            });
+          },
+        ),
       ],
       ValueListenableBuilder<FileInfo?>(
         valueListenable: _fileInfoNotifier,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -882,10 +882,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1541,26 +1541,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   tray_manager:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## ⚠️ AI-Generated Code / AI 生成代码

> **Note:** The code in this Pull Request was written entirely by AI.
> **注意：** 此 Pull Request 中的代码完全由 AI 编写。

---

## feat: Per-Profile Custom User-Agent Support

---

### Summary

Introduces per-profile User-Agent override capability, enabling fine-grained control over HTTP headers used during profile downloads and updates. This addresses compatibility issues with subscription providers that enforce strict UA-based access policies.

---

### Motivation

The existing implementation applies a single global User-Agent to all outbound profile requests. A subset of proxy subscription providers requires specific UA strings — such as `Clash.Meta`, `Clash for Windows`, or standard browser identifiers — to serve well-formed configuration payloads or to pass provider-side access controls. A global UA cannot satisfy these requirements simultaneously across multiple profiles.

---

### Changes

#### Data Layer

- Added optional `userAgent` field to the `Profile` model (`freezed`-managed).
- Extended the Drift SQLite schema with a `user_agent` column on the `profiles` table.
- Implemented a safe `onUpgrade` migration handler: duplicate-column `SqliteException` is caught and suppressed, preventing crashes on existing database instances.
- Regenerated `freezed`, `json_serializable`, and `drift` derived files.

#### Network Layer (`lib/common/request.dart`)

- Modified the `Request` utility to conditionally inject a `User-Agent` header into outgoing `dio` requests when a profile-level override is present.

#### State Management (`lib/providers/action.dart`)

- Extended `ProfilesAction` to accept and propagate a `userAgent` parameter through both the URL-based profile creation and the manual profile update flows.
- Refactored URL addition return type from `String` to `(String, String?)` tuple to carry both the URL and the selected UA in a strongly-typed manner.

#### UI (`lib/views/config/general.dart`)

- **`UaDialog`** — new reusable dialog component providing:
  - Selection from a curated preset list (Clash.Meta, Clash for Windows, Chrome, Safari, etc.).
  - Free-form custom UA input field.
- **`URLFormDialog`** — added UA selection control to the "Add Profile" flow.
- **`EditProfileView`** — added UA configuration field to the "Edit Profile" screen; displays `Global` as fallback when no override is configured.
- Design adheres to the existing Material You system (`ListItem`, standard dialog patterns).

---

### Compatibility

| Scenario | Behavior |
|---|---|
| Fresh install | `user_agent` column created as part of initial schema. |
| Upgrade from prior version | `onUpgrade` migration adds column; existing rows default to `NULL` (global UA). |
| No UA override configured | Behavior is identical to pre-patch; global default UA is used. |

---

---

## feat: 每个配置文件独立 User-Agent 支持

---

### 概述

引入基于配置文件级别的 User-Agent 覆盖机制，允许对每个配置文件的下载和更新请求独立指定 HTTP `User-Agent` 头。此功能旨在解决对 UA 有强制要求的订阅服务商的兼容性问题。

---

### 背景

现有实现对所有出站配置文件请求统一使用全局 User-Agent。部分代理订阅服务商要求请求携带特定 UA 字符串（如 `Clash.Meta`、`Clash for Windows` 或标准浏览器标识），以返回有效的配置内容或通过访问控制。单一的全局 UA 无法同时满足多个配置文件的差异化需求。

---

### 变更详情

#### 数据层

- 在 `Profile` 模型（由 `freezed` 管理）中新增可选字段 `userAgent`。
- 扩展 Drift SQLite 数据库 Schema，在 `profiles` 表中新增 `user_agent` 列。
- 实现安全的 `onUpgrade` 迁移策略：捕获并忽略因重复列触发的 `SqliteException`，防止现有数据库在应用初始化时崩溃。
- 同步更新 `freezed`、`json_serializable` 和 `drift` 的代码生成文件。

#### 网络层（`lib/common/request.dart`）

- 修改 `Request` 工具类：当配置文件存在 UA 覆盖值时，在 `dio` 出站请求中动态注入 `User-Agent` 请求头。

#### 状态管理（`lib/providers/action.dart`）

- 扩展 `ProfilesAction`，在通过 URL 创建配置文件和手动更新配置文件的流程中，接受并传递 `userAgent` 参数。
- 将 URL 添加流程的返回类型由 `String` 重构为强类型元组 `(String, String?)`，以同时携带 URL 与所选 UA。

#### UI 层（`lib/views/config/general.dart`）

- **`UaDialog`** — 新增可复用的 UA 选择对话框，支持：
  - 从内置预设列表中选择（Clash.Meta、Clash for Windows、Chrome、Safari 等）。
  - 手动输入自定义 UA 字符串。
- **`URLFormDialog`** — 在"添加配置"流程中新增 UA 选择控件。
- **`EditProfileView`** — 在"编辑配置"界面新增 UA 配置项；未设置覆盖值时，优雅回退并显示 `Global`（全局默认）标识。
- UI 设计与现有 Material You 规范（`ListItem`、标准对话框样式）保持一致。

---

### 兼容性说明

| 场景 | 行为 |
|---|---|
| 全新安装 | `user_agent` 列作为初始 Schema 的一部分创建。 |
| 从旧版本升级 | `onUpgrade` 迁移自动添加该列；现有行默认为 `NULL`（使用全局 UA）。 |
| 未配置 UA 覆盖 | 行为与更新前完全一致，继续使用全局默认 User-Agent。 |
