### PR TITLE
Make window close independent from back-blocked UI state

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -284,7 +284,7 @@ class HomeBackScopeContainer extends ConsumerWidget {
         final canPop = Navigator.canPop(realContext);
         if (canPop) {
           Navigator.of(realContext).pop();
-        } else {
+        } else if (!ref.read(backBlockProvider)) {
           await globalState.container
               .read(systemActionProvider.notifier)
               .handleBackOrExit();

--- a/lib/providers/action.dart
+++ b/lib/providers/action.dart
@@ -594,7 +594,6 @@ class SystemAction extends _$SystemAction {
   }
 
   Future<void> handleBackOrExit() async {
-    if (ref.read(backBlockProvider)) return;
     if (ref.read(appSettingProvider).minimizeOnExit) {
       if (system.isDesktop) {
         await preferences.saveConfig(ref.read(configProvider));


### PR DESCRIPTION
## 问题

连接/请求页面进入筛选搜索时会设置 `backBlock = true`，原来的 `handleBackOrExit()` 内部会读取这个状态并直接返回。桌面窗口关闭、标题栏关闭按钮、`Ctrl+W` 也都走 `handleBackOrExit()`，所以搜索态下窗口关闭被误拦截，表现为窗口无法关闭。

## 修复

把 `backBlock` 判断从 `SystemAction.handleBackOrExit()` 移到普通系统返回入口 `HomeBackScopeContainer`。这样：

- 手机/系统返回仍会先让 `CommonPopScope` 处理搜索/编辑状态，必要时由 `backBlock` 阻止继续最小化/退出。
- 桌面窗口关闭、标题栏关闭、`Ctrl+W` 直接执行应用级关闭策略，不再被搜索/编辑态拦住。
- `handleBackOrExit()` 职责更清晰，只负责根据 `minimizeOnExit` 决定隐藏到后台/托盘或真正退出。