### PR TITLE
fix: new rule overwrites existing rule with duplicate id -1

### DIFF
--- a/lib/features/overwrite/rule.dart
+++ b/lib/features/overwrite/rule.dart
@@ -251,7 +251,7 @@ class _AddOrEditRuleDialogState extends State<AddOrEditRuleDialog> {
       return;
     }
     final rule = Rule(
-      id: widget.rule?.id ?? -1,
+      id: widget.rule?.id ?? snowflake.id,
       ruleAction: _ruleAction,
       content: _contentController.text,
       ruleTarget: _ruleTargetController.text,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fl_clash
 description: A multi-platform proxy client based on ClashMeta, simple and easy to use, open-source and ad-free.
 publish_to: 'none'
-version: 0.8.93+2026052901
+version: 0.8.94+2026060701
 environment:
   sdk: '>=3.8.0 <4.0.0'
 


### PR DESCRIPTION
When adding a new rule via AddOrEditRuleDialog, the rule was created with id: -1 (widget.rule?.id ?? -1). Since copyAndPut matches by id and the database uses insertOnConflictUpdate, adding a second new rule would overwrite the first one that also had id = -1.

Fix by generating a unique snowflake.id for new rules, consistent with how custom/rules.dart already handles this case.

Bump version to 0.8.94+2026060701.