### PR TITLE
fix: remove 99-hour hard cap on VPN timer display

### DIFF
--- a/lib/common/utils.dart
+++ b/lib/common/utils.dart
@@ -91,13 +91,10 @@ class Utils {
     }
     final diff = timeStamp / 1000;
     final inHours = (diff / 3600).floor();
-    if (inHours > 99) {
-      return '99:59:59';
-    }
     final inMinutes = (diff / 60 % 60).floor();
     final inSeconds = (diff % 60).floor();
 
-    return '${getDateStringLast2(inHours)}:${getDateStringLast2(inMinutes)}:${getDateStringLast2(inSeconds)}';
+    return '$inHours:${getDateStringLast2(inMinutes)}:${getDateStringLast2(inSeconds)}';
   }
 
   Locale? getLocaleForString(String? localString) {


### PR DESCRIPTION
## Bug

When the VPN has been running for more than 99 hours 59 minutes 59 seconds,
the running time display gets stuck at `99:59:59` and stops incrementing.

## Root Cause

`getTimeText()` in `lib/common/utils.dart:94-96` hard-codes:

```dart
if (inHours > 99) {
  return '99:59:59';
}
```

The internal `runTime` millisecond counter continues incrementing correctly,
but the display function short-circuits with a static string for any value
beyond 99:59:59.

## Fix

Removed the arbitrary cap. Hours are now displayed without two-digit padding
when they exceed 99, so the format naturally handles any duration:

- Before: `99:59:59` (stuck) → `99:59:59` (still stuck)
- After: `99:59:59` → `100:00:00` → `128:45:30` → etc.
