### PR TITLE
fix: harden Android resolve_process JNI fallback

### DIFF
--- a/android/core/src/main/cpp/core.cpp
+++ b/android/core/src/main/cpp/core.cpp
@@ -105,6 +105,9 @@ call_tun_interface_resolve_process_impl(void *tun_interface, const int protocol,
                                         const char *source,
                                         const char *target,
                                         const int uid) {
+    if (tun_interface == nullptr) {
+        return strdup("");
+    }
     ATTACH_JNI();
     const auto packageName = reinterpret_cast<jstring>(env->CallObjectMethod(
             static_cast<jobject>(tun_interface),

--- a/android/core/src/main/cpp/core.cpp
+++ b/android/core/src/main/cpp/core.cpp
@@ -2,6 +2,8 @@
 
 #ifdef LIBCLASH
 
+#include <cstring>
+
 #include "jni_helper.h"
 #include "libclash.h"
 #include "bride.h"

--- a/android/core/src/main/cpp/core.cpp
+++ b/android/core/src/main/cpp/core.cpp
@@ -118,6 +118,9 @@ call_tun_interface_resolve_process_impl(void *tun_interface, const int protocol,
             new_string(source),
             new_string(target),
             uid));
+    if (packageName == nullptr || jni_catch_exception(env)) {
+        return strdup("");
+    }
     return get_string(packageName);
 }
 

--- a/android/core/src/main/cpp/jni_helper.cpp
+++ b/android/core/src/main/cpp/jni_helper.cpp
@@ -23,7 +23,17 @@ JavaVM *global_java_vm() {
 }
 
 char *jni_get_string(JNIEnv *env, jstring str) {
+    if (str == nullptr || jni_catch_exception(env)) {
+        const auto content = static_cast<char *>(malloc(1));
+        content[0] = 0;
+        return content;
+    }
     const auto array = reinterpret_cast<jbyteArray>(env->CallObjectMethod(str, m_get_bytes));
+    if (array == nullptr || jni_catch_exception(env)) {
+        const auto content = static_cast<char *>(malloc(1));
+        content[0] = 0;
+        return content;
+    }
     const int length = env->GetArrayLength(array);
     const auto content = static_cast<char *>(malloc(length + 1));
     env->GetByteArrayRegion(array, 0, length, reinterpret_cast<jbyte *>(content));

--- a/android/service/src/main/java/com/follow/clash/service/VpnService.kt
+++ b/android/service/src/main/java/com/follow/clash/service/VpnService.kt
@@ -59,18 +59,22 @@ class VpnService : SystemVpnService(), IBaseService,
         target: InetSocketAddress,
         uid: Int,
     ): String {
-        val nextUid = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            connectivity?.getConnectionOwnerUid(protocol, source, target) ?: -1
-        } else {
-            uid
+        return runCatching {
+            val nextUid = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                connectivity?.getConnectionOwnerUid(protocol, source, target) ?: -1
+            } else {
+                uid
+            }
+            if (nextUid == -1) {
+                return@runCatching ""
+            }
+            uidPageNameMap.getOrPut(nextUid) {
+                this.packageManager?.getPackagesForUid(nextUid)?.firstOrNull() ?: ""
+            }
+        }.getOrElse {
+            GlobalState.log("resolverProcess failed: $it")
+            ""
         }
-        if (nextUid == -1) {
-            return ""
-        }
-        if (!uidPageNameMap.containsKey(nextUid)) {
-            uidPageNameMap[nextUid] = this.packageManager?.getPackagesForUid(nextUid)?.first() ?: ""
-        }
-        return uidPageNameMap[nextUid] ?: ""
     }
 
     val VpnOptions.address

--- a/core/lib.go
+++ b/core/lib.go
@@ -84,7 +84,7 @@ func (th *TunHandler) handleResolveProcess(source, target net.Addr) string {
 	_ = th.limit.Acquire(context.Background(), 1)
 	defer th.limit.Release(1)
 
-	if th.listener == nil {
+	if th.listener == nil || th.callback == nil {
 		return ""
 	}
 	var protocol int


### PR DESCRIPTION
## Summary

This hardens the Android process resolver JNI bridge so the `:remote` process does not abort when process/package resolution cannot produce a valid Java string.

Fixes/addresses the crash reported in #1995 and builds on the approach from #1996.

## What changed

- Guard `TunHandler.handleResolveProcess()` against a nil callback before entering CGO.
- Guard `call_tun_interface_resolve_process_impl()` against a null `tun_interface`, a null Java return value, and pending Java exceptions.
- Make `jni_get_string()` safely return an empty C string when passed a null `jstring` or when `String.getBytes()` fails.
- Make Android `VpnService.resolverProcess()` tolerant of package visibility/filtering edge cases by using `firstOrNull()` and `runCatching`.

## Why

#1996 covers the direct null callback case, but real-device testing still reproduced the same ART abort when the Java resolver path failed or returned null. In particular, `getPackagesForUid(...).first()` can throw when package visibility/filtering returns an empty array; native code then continued through JNI with a null object and triggered:

```text
JNI DETECTED ERROR IN APPLICATION: obj == null
    in call to CallObjectMethodV
```

Returning an empty package name is already treated as the fallback path by the resolver, so these guards keep the VPN running instead of aborting the `:remote` process.

## Testing

- Built an Android arm64 public-signed release APK from this branch.
- Tested on a real device: Nothing/Asteroids, Android 16 (`BQ2A.250721.001-BP2A.250605.031.A3`).
- Verified against the previously reproducible `com.follow.clash:remote` / `resolve_process` SIGABRT path.

This fix was produced by Codex with GPT-5.5 assistance and validated with real-device testing.
