### PR TITLE
fix: reduce idle CPU usage on macOS (tray title dedup, pause hidden-w…

### DIFF
--- a/lib/common/render.dart
+++ b/lib/common/render.dart
@@ -16,6 +16,8 @@ class Render {
     return _instance!;
   }
 
+  bool get isPaused => _isPaused;
+
   void active() {
     resume();
     pause();

--- a/lib/common/tray.dart
+++ b/lib/common/tray.dart
@@ -16,6 +16,8 @@ import 'window.dart';
 class Tray {
   static Tray? _instance;
 
+  String? _lastTrayTitle;
+
   Tray._internal();
 
   factory Tray() {
@@ -28,6 +30,7 @@ class Tray {
   }
 
   Future<void> destroy() async {
+    _lastTrayTitle = null;
     await trayManager.destroy();
   }
 
@@ -207,11 +210,14 @@ class Tray {
     if (!system.isMacOS) {
       return;
     }
-    if (!showTrayTitle) {
-      await trayManager.setTitle('');
-    } else {
-      await trayManager.setTitle(traffic.trayTitle);
+    // Repeated setTitle calls (even with an unchanged value) force a full
+    // NSStatusItem replicant redraw on newer macOS, which pins the CPU.
+    final title = showTrayTitle ? traffic.trayTitle : '';
+    if (title == _lastTrayTitle) {
+      return;
     }
+    _lastTrayTitle = title;
+    await trayManager.setTitle(title);
   }
 
   Future<void> _copyEnv(int port) async {

--- a/lib/core/event.dart
+++ b/lib/core/event.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:fl_clash/common/render.dart';
 import 'package:fl_clash/enum/enum.dart';
 import 'package:fl_clash/models/models.dart';
 import 'package:flutter/foundation.dart';
@@ -30,6 +31,11 @@ class CoreEventManager {
             listener.onDelay(Delay.fromJson(event.data));
             break;
           case CoreEventType.request:
+            // Under TUN the core pushes a message per connection; parsing
+            // them while the window is hidden burns CPU for data no one sees.
+            if (render?.isPaused == true) {
+              break;
+            }
             listener.onRequest(TrackerInfo.fromJson(event.data));
             break;
           case CoreEventType.loaded:

--- a/lib/core/interface.dart
+++ b/lib/core/interface.dart
@@ -75,6 +75,12 @@ mixin CoreInterface {
 }
 
 abstract class CoreHandlerInterface with CoreInterface {
+  // Polled every second; logging them floods the log list and wastes CPU.
+  static const _silentMethods = {
+    ActionMethod.getTraffic,
+    ActionMethod.getTotalTraffic,
+  };
+
   Completer get completer;
 
   FutureOr<bool> destroy();
@@ -93,14 +99,17 @@ abstract class CoreHandlerInterface with CoreInterface {
       );
       return null;
     }
+    final silent = _silentMethods.contains(method);
     return await utils.handleWatch(
       onStart: () {
+        if (silent) return;
         commonPrint.log('Invoke ${method.name} ${DateTime.now()} $data');
       },
       function: () async {
         return invoke<T>(method: method, data: data, timeout: timeout);
       },
       onEnd: (data, elapsedMilliseconds) {
+        if (silent) return;
         commonPrint.log('Invoke ${method.name} ${elapsedMilliseconds}ms');
       },
     );

--- a/lib/providers/action.dart
+++ b/lib/providers/action.dart
@@ -145,6 +145,12 @@ class SetupAction extends _$SetupAction {
       await coreController.startListener();
     }
     _updateTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      // While the window is hidden and the tray title is off, nothing
+      // consumes these values; skip the per-second core IPC round-trips.
+      if (render?.isPaused == true &&
+          !ref.read(appSettingProvider).showTrayTitle) {
+        return;
+      }
       ref.read(commonActionProvider.notifier).updateRunTime();
       ref.read(commonActionProvider.notifier).updateTraffic();
     });

--- a/lib/providers/state.dart
+++ b/lib/providers/state.dart
@@ -159,6 +159,11 @@ TrayTitleState trayTitleState(Ref ref) {
   final showTrayTitle = ref.watch(
     appSettingProvider.select((state) => state.showTrayTitle),
   );
+  // Avoid subscribing to per-second traffic updates when the tray title is
+  // hidden, so the tray listener doesn't fire every second for nothing.
+  if (!showTrayTitle) {
+    return const TrayTitleState(showTrayTitle: false, traffic: Traffic());
+  }
   final traffic = ref.watch(
     trafficsProvider.select((state) => state.list.safeLast(const Traffic())),
   );


### PR DESCRIPTION
…indow polling)

On newer macOS versions (especially with TUN enabled), FlClash keeps a constant 40-50% CPU load in the background. Four independent per-second hot paths cause this:

- Tray.updateTrayTitle called trayManager.setTitle every second even when the value was unchanged or the tray title was disabled. Each setTitle triggers a full NSStatusItem redraw on recent macOS. Now the last title is cached and the native call is skipped when unchanged.
- trayTitleState subscribed to per-second traffic updates even with showTrayTitle off. It now returns a constant state in that case.
- The 1s runtime/traffic poll timer now skips its two core IPC round-trips while the window is hidden and the tray title is off (nothing consumes those values). Resumes automatically on show.
- getTraffic/getTotalTraffic invocations no longer emit two log entries per second each; other methods keep logging as before.
- Request push messages from the core (one per connection under TUN) are no longer JSON-parsed while the window is hidden.

No behavior change while the window is visible.