### PR TITLE
Fix macOS startup hang during Wi-Fi SSID lookup

### DIFF
--- a/lib/common/permission.dart
+++ b/lib/common/permission.dart
@@ -74,9 +74,11 @@ class Permissions {
         final res = await WifiSsidManager.instance.requestPermission();
         globalState.container.read(locationPermissionsProvider.notifier).value =
             res;
-        if (res != WifiSsidPermission.granted) {
+        if (res == WifiSsidPermission.granted) {
           final ssid = await WifiSsidManager.instance.getSsid();
           globalState.container.read(currentSSIDProvider.notifier).value = ssid;
+        } else {
+          globalState.container.read(currentSSIDProvider.notifier).value = null;
         }
       } finally {
         _isRequestingLocation = false;

--- a/lib/manager/connectivity_manager.dart
+++ b/lib/manager/connectivity_manager.dart
@@ -24,16 +24,14 @@ class ConnectivityManager extends StatefulWidget {
 
 class _ConnectivityManagerState extends State<ConnectivityManager> {
   late StreamSubscription subscription;
+  int _ssidRefreshVersion = 0;
 
   @override
   void initState() {
     super.initState();
     subscription = Connectivity().onConnectivityChanged.listen((results) {
       if (results.contains(ConnectivityResult.wifi)) {
-        WifiSsidManager.instance.getSsid().then((ssid) {
-          globalState.container.read(currentSSIDProvider.notifier).value = ssid;
-          commonPrint.log('Wi-fi SSID: $ssid ', logLevel: LogLevel.info);
-        });
+        _updateCurrentSsid();
       } else {
         globalState.container.read(currentSSIDProvider.notifier).value = null;
       }
@@ -43,8 +41,33 @@ class _ConnectivityManagerState extends State<ConnectivityManager> {
     });
   }
 
+  Future<void> _updateCurrentSsid() async {
+    final version = ++_ssidRefreshVersion;
+    final permission = await WifiSsidManager.instance.checkPermission();
+    if (!mounted || version != _ssidRefreshVersion) {
+      return;
+    }
+    globalState.container.read(locationPermissionsProvider.notifier).value =
+        permission;
+    if (permission != WifiSsidPermission.granted) {
+      globalState.container.read(currentSSIDProvider.notifier).value = null;
+      commonPrint.log(
+        'Wi-fi SSID skipped: location permission is $permission',
+        logLevel: LogLevel.info,
+      );
+      return;
+    }
+    final ssid = await WifiSsidManager.instance.getSsid();
+    if (!mounted || version != _ssidRefreshVersion) {
+      return;
+    }
+    globalState.container.read(currentSSIDProvider.notifier).value = ssid;
+    commonPrint.log('Wi-fi SSID: $ssid ', logLevel: LogLevel.info);
+  }
+
   @override
   void dispose() {
+    _ssidRefreshVersion++;
     subscription.cancel();
     super.dispose();
   }

--- a/lib/views/config/on_demand.dart
+++ b/lib/views/config/on_demand.dart
@@ -48,7 +48,16 @@ class _OnDemandViewState extends ConsumerState<OnDemandView>
     final res = await wifiSsidManager.requestPermission();
     globalState.container.read(locationPermissionsProvider.notifier).value =
         res;
-    if (!mounted && res != WifiSsidPermission.permanentlyDenied) {
+    if (!mounted) {
+      return;
+    }
+    if (res == WifiSsidPermission.granted) {
+      final ssid = await wifiSsidManager.getSsid();
+      globalState.container.read(currentSSIDProvider.notifier).value = ssid;
+      return;
+    }
+    if (res == WifiSsidPermission.permanentlyDenied) {
+      _handlePermanentlyDeniedLocationPermission();
       return;
     }
     final needGo = await globalState.showMessage(
@@ -76,9 +85,8 @@ class _OnDemandViewState extends ConsumerState<OnDemandView>
     final appLocalizations = context.appLocalizations;
     final newSSID = await globalState.showCommonDialog<String>(
       child: InputDialog(
-        title: ssid == null
-            ? appLocalizations.addSsid
-            : appLocalizations.editSsid,
+        title:
+            ssid == null ? appLocalizations.addSsid : appLocalizations.editSsid,
         value: ssid ?? '',
         maxLength: 32,
         validator: (value) {
@@ -229,8 +237,8 @@ class _OnDemandViewState extends ConsumerState<OnDemandView>
                                     style: FilledButton.styleFrom(
                                       backgroundColor:
                                           batteryOptimizationDisable
-                                          ? null
-                                          : context.colorScheme.error,
+                                              ? null
+                                              : context.colorScheme.error,
                                       padding: const EdgeInsets.symmetric(
                                         horizontal: 12,
                                       ),

--- a/plugins/wifi_ssid/lib/wifi_ssid_manager.dart
+++ b/plugins/wifi_ssid/lib/wifi_ssid_manager.dart
@@ -10,24 +10,45 @@ class WifiSsidManager {
   WifiSsidManager._();
 
   static final WifiSsidManager instance = WifiSsidManager._();
+  static const _timeout = Duration(seconds: 3);
 
   final MethodChannel _channel = const MethodChannel('wifi_ssid');
 
   /// Returns the current WiFi SSID, or null if not connected to WiFi.
   Future<String?> getSsid() async {
-    return await _channel.invokeMethod<String>('getSsid');
+    try {
+      return await _channel
+          .invokeMethod<String>('getSsid')
+          .timeout(_timeout, onTimeout: () => null);
+    } on PlatformException {
+      return null;
+    } on MissingPluginException {
+      return null;
+    }
   }
 
   /// Checks whether location permission has been granted.
   Future<WifiSsidPermission> checkPermission() async {
-    final result = await _channel.invokeMethod<int>('checkPermission');
+    final result = await _invokePermissionMethod('checkPermission');
     return WifiSsidPermission.values[result ?? 1];
   }
 
   /// Requests location permission from the user.
   Future<WifiSsidPermission> requestPermission() async {
-    final result = await _channel.invokeMethod<int>('requestPermission');
+    final result = await _invokePermissionMethod('requestPermission');
     return WifiSsidPermission.values[result ?? 1];
+  }
+
+  Future<int?> _invokePermissionMethod(String method) async {
+    try {
+      return await _channel
+          .invokeMethod<int>(method)
+          .timeout(_timeout, onTimeout: () => 1);
+    } on PlatformException {
+      return 1;
+    } on MissingPluginException {
+      return 1;
+    }
   }
 }
 

--- a/plugins/wifi_ssid/macos/Classes/WifiSsidPlugin.swift
+++ b/plugins/wifi_ssid/macos/Classes/WifiSsidPlugin.swift
@@ -9,6 +9,8 @@ public class WifiSsidPlugin: NSObject, FlutterPlugin, CLLocationManagerDelegate 
 
     private let locationManager = CLLocationManager()
     private var pendingPermissionResult: FlutterResult?
+    private let ssidQueue = DispatchQueue(label: "com.follow.clash.wifi-ssid", qos: .utility)
+    private let ssidTimeout: TimeInterval = 2.0
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(
@@ -46,12 +48,16 @@ public class WifiSsidPlugin: NSObject, FlutterPlugin, CLLocationManagerDelegate 
 
     private func requestPermission(result: @escaping FlutterResult) {
         let status = locationManager.authorizationStatus
-        if status == .authorizedAlways {
+        if isAuthorized(status) {
             result(0) // granted
             return
         }
-        if status == .denied {
+        if status == .denied || status == .restricted {
             result(2) // permanentlyDenied
+            return
+        }
+        if pendingPermissionResult != nil {
+            result(mapAuthStatus(status).rawValue)
             return
         }
         pendingPermissionResult = result
@@ -65,13 +71,25 @@ public class WifiSsidPlugin: NSObject, FlutterPlugin, CLLocationManagerDelegate 
     }
 
     private func mapAuthStatus(_ status: CLAuthorizationStatus) -> WifiSsidPermission {
-        switch status {
-        case .authorizedAlways:
+        if isAuthorized(status) {
             return .granted
+        }
+        switch status {
         case .denied, .restricted:
             return .permanentlyDenied
         default:
             return .denied
+        }
+    }
+
+    private func isAuthorized(_ status: CLAuthorizationStatus) -> Bool {
+        switch status {
+        case .authorizedAlways:
+            return true
+        case .authorizedWhenInUse:
+            return true
+        default:
+            return false
         }
     }
 
@@ -84,14 +102,36 @@ public class WifiSsidPlugin: NSObject, FlutterPlugin, CLLocationManagerDelegate 
     // MARK: - SSID
 
     private func getSsid(result: @escaping FlutterResult) {
-        if #available(macOS 10.10, *) {
-            if let interface = CWWiFiClient.shared().interface() {
-                result(interface.ssid())
-            } else {
-                result(nil)
-            }
-        } else {
+        guard isAuthorized(locationManager.authorizationStatus) else {
             result(nil)
+            return
+        }
+
+        guard #available(macOS 10.10, *) else {
+            result(nil)
+            return
+        }
+
+        var didComplete = false
+        let lock = NSLock()
+
+        func complete(_ value: String?) {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !didComplete else { return }
+            didComplete = true
+            DispatchQueue.main.async {
+                result(value)
+            }
+        }
+
+        ssidQueue.async {
+            let ssid = CWWiFiClient.shared().interface()?.ssid()
+            complete(ssid)
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + ssidTimeout) {
+            complete(nil)
         }
     }
 }

--- a/plugins/wifi_ssid/test/wifi_ssid_manager_test.dart
+++ b/plugins/wifi_ssid/test/wifi_ssid_manager_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wifi_ssid/wifi_ssid.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('wifi_ssid');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  group('WifiSsidManager', () {
+    test('returns null when getSsid throws a platform exception', () async {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        expect(call.method, 'getSsid');
+        throw PlatformException(code: 'UNAVAILABLE');
+      });
+
+      final ssid = await wifiSsidManager.getSsid();
+
+      expect(ssid, isNull);
+    });
+
+    test('returns denied when checkPermission throws a platform exception',
+        () async {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        expect(call.method, 'checkPermission');
+        throw PlatformException(code: 'UNAVAILABLE');
+      });
+
+      final permission = await wifiSsidManager.checkPermission();
+
+      expect(permission, WifiSsidPermission.denied);
+    });
+
+    test('returns denied when requestPermission throws a platform exception',
+        () async {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        expect(call.method, 'requestPermission');
+        throw PlatformException(code: 'UNAVAILABLE');
+      });
+
+      final permission = await wifiSsidManager.requestPermission();
+
+      expect(permission, WifiSsidPermission.denied);
+    });
+
+    test('maps native permission indexes to Dart enum values', () async {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        return WifiSsidPermission.permanentlyDenied.index;
+      });
+
+      final permission = await wifiSsidManager.checkPermission();
+
+      expect(permission, WifiSsidPermission.permanentlyDenied);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- make macOS Wi-Fi SSID lookup permission-aware before touching CoreWLAN
- move native SSID reads off the main queue and complete them with a timeout
- make Dart-side SSID/permission calls fail safely instead of blocking startup
- refresh SSID after manual location permission grants and improve denied guidance

Fixes #2188

## Testing
- `swiftc -parse -parse-as-library plugins/wifi_ssid/macos/Classes/WifiSsidPlugin.swift`
- `flutter test plugins/wifi_ssid/test/wifi_ssid_manager_test.dart`
- `git diff --check`
