### PR TITLE
fix: deduplicate macOS tray title updates to stop NSStatusItem CPU spin

### DIFF
--- a/lib/common/tray.dart
+++ b/lib/common/tray.dart
@@ -16,6 +16,8 @@ import 'window.dart';
 class Tray {
   static Tray? _instance;
 
+  String? _lastTrayTitle;
+
   Tray._internal();
 
   factory Tray() {
@@ -28,6 +30,7 @@ class Tray {
   }
 
   Future<void> destroy() async {
+    _lastTrayTitle = null;
     await trayManager.destroy();
   }
 
@@ -207,11 +210,16 @@ class Tray {
     if (!system.isMacOS) {
       return;
     }
-    if (!showTrayTitle) {
-      await trayManager.setTitle('');
-    } else {
-      await trayManager.setTitle(traffic.trayTitle);
+    // Repeated setTitle calls (even with an unchanged value) force a full
+    // NSStatusItem replicant redraw on newer macOS, which pins the CPU.
+    final title = showTrayTitle ? traffic.trayTitle : '';
+    if (title == _lastTrayTitle) {
+      return;
     }
+    // Assign after a successful platform call so a failed setTitle can retry
+    // the same title on the next update.
+    await trayManager.setTitle(title);
+    _lastTrayTitle = title;
   }
 
   Future<void> _copyEnv(int port) async {

--- a/lib/providers/state.dart
+++ b/lib/providers/state.dart
@@ -159,6 +159,11 @@ TrayTitleState trayTitleState(Ref ref) {
   final showTrayTitle = ref.watch(
     appSettingProvider.select((state) => state.showTrayTitle),
   );
+  // Avoid subscribing to per-second traffic updates when the tray title is
+  // hidden, so the tray listener doesn't fire every second for nothing.
+  if (!showTrayTitle) {
+    return const TrayTitleState(showTrayTitle: false, traffic: Traffic());
+  }
   final traffic = ref.watch(
     trafficsProvider.select((state) => state.list.safeLast(const Traffic())),
   );

--- a/test/common/tray_test.dart
+++ b/test/common/tray_test.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
 
 import 'package:fl_clash/common/tray.dart';
-import 'package:test/test.dart';
+import 'package:fl_clash/models/models.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Tray.getTryIcon', () {
@@ -32,5 +34,125 @@ void main() {
             : 'assets/images/icon/status_3.$suffix',
       );
     });
+  });
+
+  group('Tray.updateTrayTitle deduplication', () {
+    TestWidgetsFlutterBinding.ensureInitialized();
+
+    late Tray tray;
+    late List<MethodCall> calls;
+
+    setUp(() {
+      tray = Tray();
+      calls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(const MethodChannel('tray_manager'), (
+            call,
+          ) async {
+            calls.add(call);
+            return null;
+          });
+    });
+
+    tearDown(() async {
+      await tray.destroy();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(const MethodChannel('tray_manager'), null);
+    });
+
+    test(
+      'skips repeated setTitle when the title is unchanged',
+      () async {
+        await tray.updateTrayTitle(
+          showTrayTitle: false,
+          traffic: const Traffic(),
+        );
+        await tray.updateTrayTitle(
+          showTrayTitle: false,
+          traffic: const Traffic(),
+        );
+        await tray.updateTrayTitle(
+          showTrayTitle: false,
+          traffic: const Traffic(),
+        );
+
+        final setTitleCalls = calls
+            .where((call) => call.method == 'setTitle')
+            .toList();
+        expect(setTitleCalls, hasLength(1));
+        expect(setTitleCalls.single.arguments, {'title': ''});
+      },
+      skip: !Platform.isMacOS
+          ? 'updateTrayTitle is macOS-only'
+          : false,
+    );
+
+    test(
+      'calls setTitle again after destroy resets the title cache',
+      () async {
+        await tray.updateTrayTitle(
+          showTrayTitle: false,
+          traffic: const Traffic(),
+        );
+        expect(
+          calls.where((call) => call.method == 'setTitle'),
+          hasLength(1),
+        );
+
+        await tray.destroy();
+        calls.clear();
+
+        await tray.updateTrayTitle(
+          showTrayTitle: false,
+          traffic: const Traffic(),
+        );
+        expect(
+          calls.where((call) => call.method == 'setTitle'),
+          hasLength(1),
+        );
+      },
+      skip: !Platform.isMacOS
+          ? 'updateTrayTitle is macOS-only'
+          : false,
+    );
+
+    test(
+      'does not cache the title when setTitle fails',
+      () async {
+        var shouldFail = true;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(const MethodChannel('tray_manager'), (
+              call,
+            ) async {
+              calls.add(call);
+              if (call.method == 'setTitle' && shouldFail) {
+                throw PlatformException(code: 'setTitle_failed');
+              }
+              return null;
+            });
+
+        await expectLater(
+          tray.updateTrayTitle(
+            showTrayTitle: false,
+            traffic: const Traffic(),
+          ),
+          throwsA(isA<PlatformException>()),
+        );
+
+        shouldFail = false;
+        await tray.updateTrayTitle(
+          showTrayTitle: false,
+          traffic: const Traffic(),
+        );
+
+        expect(
+          calls.where((call) => call.method == 'setTitle'),
+          hasLength(2),
+        );
+      },
+      skip: !Platform.isMacOS
+          ? 'updateTrayTitle is macOS-only'
+          : false,
+    );
   });
 }


### PR DESCRIPTION
## Summary
- Deduplicate macOS `trayManager.setTitle` calls (cache last title; assign only after a successful platform call)
- Reset the title cache in `destroy()`
- Stop watching per-second traffic when `showTrayTitle` is off
- Add MethodChannel tests for dedup, destroy reset, and failed-setTitle retry

Addresses the disabled-title high-CPU case in #1644.

This is a minimal split from #2186 (tray-title only). Hidden-window polling / request-parsing / silent-IPC logging can follow in a separate PR.

## Test plan
- [ ] `showTrayTitle=false`, window hidden: CPU near 0% (esp. multi-display + "Displays have separate Spaces")
- [ ] Toggle tray title on/off: title updates correctly; no stuck empty/non-empty title
- [ ] `flutter test test/common/tray_test.dart` (MethodChannel cases run on macOS)