### PR TITLE
fix: reduce macOS idle CPU when window is hidden

### DIFF
--- a/lib/common/render.dart
+++ b/lib/common/render.dart
@@ -16,6 +16,8 @@ class Render {
     return _instance!;
   }
 
+  bool get isPaused => _isPaused;
+
   void active() {
     resume();
     pause();

--- a/lib/core/event.dart
+++ b/lib/core/event.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:fl_clash/common/render.dart';
 import 'package:fl_clash/enum/enum.dart';
 import 'package:fl_clash/models/models.dart';
 import 'package:flutter/foundation.dart';
@@ -30,6 +31,11 @@ class CoreEventManager {
             listener.onDelay(Delay.fromJson(event.data));
             break;
           case CoreEventType.request:
+            // Under TUN the core pushes a message per connection; parsing
+            // them while the window is hidden burns CPU for data no one sees.
+            if (render?.isPaused == true) {
+              break;
+            }
             listener.onRequest(TrackerInfo.fromJson(event.data));
             break;
           case CoreEventType.loaded:

--- a/lib/core/interface.dart
+++ b/lib/core/interface.dart
@@ -75,6 +75,12 @@ mixin CoreInterface {
 }
 
 abstract class CoreHandlerInterface with CoreInterface {
+  // Polled every second; logging them floods the log list and wastes CPU.
+  static const _silentMethods = {
+    ActionMethod.getTraffic,
+    ActionMethod.getTotalTraffic,
+  };
+
   Completer get completer;
 
   FutureOr<bool> destroy();
@@ -93,14 +99,17 @@ abstract class CoreHandlerInterface with CoreInterface {
       );
       return null;
     }
+    final silent = _silentMethods.contains(method);
     return await utils.handleWatch(
       onStart: () {
+        if (silent) return;
         commonPrint.log('Invoke ${method.name} ${DateTime.now()} $data');
       },
       function: () async {
         return invoke<T>(method: method, data: data, timeout: timeout);
       },
       onEnd: (data, elapsedMilliseconds) {
+        if (silent) return;
         commonPrint.log('Invoke ${method.name} ${elapsedMilliseconds}ms');
       },
     );

--- a/lib/providers/action.dart
+++ b/lib/providers/action.dart
@@ -145,6 +145,12 @@ class SetupAction extends _$SetupAction {
       await coreController.startListener();
     }
     _updateTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      // While the window is hidden and the tray title is off, nothing
+      // consumes these values; skip the per-second core IPC round-trips.
+      if (render?.isPaused == true &&
+          !ref.read(appSettingProvider).showTrayTitle) {
+        return;
+      }
       ref.read(commonActionProvider.notifier).updateRunTime();
       ref.read(commonActionProvider.notifier).updateTraffic();
     });


### PR DESCRIPTION
## Summary
Follow-up to #2201 (tray-title dedup). Remaining idle-CPU reductions when the window is hidden:

- Pause per-second `updateRunTime` / `updateTraffic` core IPC while `Render.isPaused` and `showTrayTitle` is off
- Skip parsing TUN `request` push events while the window is hidden
- Stop logging every `getTraffic` / `getTotalTraffic` invoke

These are independent of the tray `setTitle` fix in #2201 / #1644.

## Test plan
- [ ] Window hidden, tray title off, TUN on: CPU stays low
- [ ] Re-show window: runtime/traffic and connections UI update again within ~1s
- [ ] With tray title on while hidden: traffic polling still runs for the tray
- [ ] Proxy still works while hidden

Supersedes the non-tray parts of #2186.