### PR TITLE
fix: restrict SSL certificate bypass to localhost only

### DIFF
--- a/lib/common/http.dart
+++ b/lib/common/http.dart
@@ -24,7 +24,9 @@ class FlClashHttpOverrides extends HttpOverrides {
   @override
   HttpClient createHttpClient(SecurityContext? context) {
     final client = super.createHttpClient(context);
-    client.badCertificateCallback = (_, _, _) => true;
+    client.badCertificateCallback = (X509Certificate cert, String host, int port) {
+      return [localhost, 'localhost'].contains(host);
+    };
     client.findProxy = handleFindProxy;
     return client;
   }


### PR DESCRIPTION
## Problem

`lib/common/http.dart:27` disables SSL certificate validation for **all** HTTP connections:

```dart
client.badCertificateCallback = (_, _, _) => true;
```

This affects subscription downloads, update checks, and WebDAV sync — all of which connect to external servers over HTTPS. An attacker on the same network can perform man-in-the-middle attacks to inject malicious proxy nodes, redirect updates, or steal credentials.

### Why the bypass exists

The app routes external traffic through the local ClashMeta proxy via `handleFindProxy`, which returns `PROXY localhost:$mixedPort`. The proxy handles outbound TLS. The Flutter app only needs certificate bypass for **local proxy connections**, not external endpoints.

## Fix

Restrict `badCertificateCallback` to only bypass validation for local addresses:

```dart
client.badCertificateCallback = (X509Certificate cert, String host, int port) {
  return host == localhost || host == 'localhost';
};
```

### Why two checks

- `localhost` is `const localhost = '127.0.0.1'` (`lib/common/constant.dart:55`) — the IP address
- `'localhost'` is the hostname string — this is what `handleFindProxy` returns in the proxy URL (`PROXY localhost:$mixedPort`)

When the HTTP client connects through the proxy, it uses the hostname from the proxy URL. Depending on DNS resolution and platform behavior, the `host` parameter in the callback may receive either `'127.0.0.1'` or `'localhost'`. Both must be handled.

### Scope

| Connection type | Before | After |
|---|---|---|
| `127.0.0.1` (local proxy) | Bypass | Bypass |
| `localhost` hostname (local proxy) | Bypass | Bypass |
| External HTTPS (subscriptions, updates, WebDAV) | Bypass | Validate |

### IPv6

IPv6 (`::1`) is not included because the codebase consistently uses IPv4 for local connections. The `localhost` constant, `defaultExternalController`, and proxy configuration all use `127.0.0.1`. If IPv6 support is added later, the callback can be extended.
