### PR TITLE
feat: 添加 Android AppWidget 支持

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "core/Clash.Meta"]
 	path = core/Clash.Meta
-	url = git@github.com:chen08209/Clash.Meta.git
+	url = https://github.com/chen08209/Clash.Meta.git
 	branch = FlClash

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,6 +5,12 @@ analyzer:
     - lib/l10n/intl/**
     - lib/**/generated/**
     - plugins/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   errors:
     invalid_annotation_target: ignore
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -84,6 +84,10 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <action android:name="${applicationId}.action.TOGGLE" />
             </intent-filter>
+            <intent-filter>
+                <category android:name="android.intent.category.DEFAULT" />
+                <action android:name="${applicationId}.action.SELECT_PROXY" />
+            </intent-filter>
         </activity>
 
         <service
@@ -109,6 +113,26 @@
                 <action android:name="${applicationId}.intent.action.SERVICE_CREATED" />
                 <action android:name="${applicationId}.intent.action.SERVICE_DESTROYED" />
             </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".WidgetProvider"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="${applicationId}.action.CYCLE_MODE" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="${applicationId}.action.CYCLE_NODE" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="${applicationId}.action.SELECT_PROXY" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_info" />
         </receiver>
 
         <meta-data

--- a/android/app/src/main/kotlin/com/follow/clash/BroadcastReceiver.kt
+++ b/android/app/src/main/kotlin/com/follow/clash/BroadcastReceiver.kt
@@ -1,6 +1,8 @@
 package com.follow.clash
 
+import android.appwidget.AppWidgetManager
 import android.content.BroadcastReceiver
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import com.follow.clash.common.BroadcastAction
@@ -10,20 +12,36 @@ import kotlinx.coroutines.launch
 
 class BroadcastReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
+        val ctx = context ?: return
         when (intent?.action) {
             BroadcastAction.SERVICE_CREATED.action -> {
                 GlobalState.log("Receiver service created")
                 GlobalState.launch {
                     State.handleStartServiceAction()
                 }
+                val currentState = WidgetDataStore.getState(ctx)
+                WidgetDataStore.saveState(ctx, currentState.copy(isStart = true))
+                refreshWidget(ctx)
             }
 
             BroadcastAction.SERVICE_DESTROYED.action -> {
                 GlobalState.log("Receiver service destroyed")
+                val currentState = WidgetDataStore.getState(ctx)
+                WidgetDataStore.saveState(ctx, currentState.copy(isStart = false))
+                refreshWidget(ctx)
                 GlobalState.launch {
                     State.handleStopServiceAction()
                 }
             }
+        }
+    }
+
+    private fun refreshWidget(context: Context) {
+        val appWidgetManager = AppWidgetManager.getInstance(context)
+        val componentName = ComponentName(context, WidgetProvider::class.java)
+        val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
+        for (appWidgetId in appWidgetIds) {
+            WidgetProvider.updateWidget(context, appWidgetManager, appWidgetId)
         }
     }
 }

--- a/android/app/src/main/kotlin/com/follow/clash/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/follow/clash/MainActivity.kt
@@ -5,6 +5,7 @@ import com.follow.clash.common.GlobalState
 import com.follow.clash.plugins.AppPlugin
 import com.follow.clash.plugins.ServicePlugin
 import com.follow.clash.plugins.TilePlugin
+import com.follow.clash.plugins.WidgetPlugin
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import kotlinx.coroutines.CoroutineScope
@@ -24,6 +25,7 @@ class MainActivity : FlutterActivity(),
         flutterEngine.plugins.add(AppPlugin())
         flutterEngine.plugins.add(ServicePlugin())
         flutterEngine.plugins.add(TilePlugin())
+        flutterEngine.plugins.add(WidgetPlugin())
         State.flutterEngine = flutterEngine
     }
 

--- a/android/app/src/main/kotlin/com/follow/clash/State.kt
+++ b/android/app/src/main/kotlin/com/follow/clash/State.kt
@@ -1,11 +1,17 @@
 package com.follow.clash
 
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Intent
 import android.net.VpnService
+import com.follow.clash.common.AccessControlMode
 import com.follow.clash.common.GlobalState
 import com.follow.clash.models.SharedState
 import com.follow.clash.plugins.AppPlugin
 import com.follow.clash.plugins.TilePlugin
+import com.follow.clash.service.models.AccessControlProps
 import com.follow.clash.service.models.NotificationParams
+import com.follow.clash.service.models.VpnOptions
 import com.google.gson.Gson
 import io.flutter.embedding.engine.FlutterEngine
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -150,6 +156,24 @@ object State {
         )
     }
 
+    fun defaultVpnOptions(): VpnOptions = VpnOptions(
+        enable = true,
+        port = 7890,
+        ipv6 = false,
+        dnsHijacking = true,
+        accessControlProps = AccessControlProps(
+            enable = false,
+            mode = AccessControlMode.ACCEPT_SELECTED,
+            acceptList = emptyList(),
+            rejectList = emptyList(),
+        ),
+        allowBypass = false,
+        systemProxy = true,
+        bypassDomain = emptyList(),
+        stack = "system",
+        routeAddress = emptyList(),
+    )
+
     private fun startService() {
         GlobalState.launch {
             runLock.withLock {
@@ -158,19 +182,23 @@ object State {
                 }
                 try {
                     runStateFlow.tryEmit(RunState.PENDING)
-                    val options = sharedState.vpnOptions ?: return@launch
+                    val options = sharedState.vpnOptions ?: defaultVpnOptions()
                     appPlugin?.let {
                         it.prepare(options.enable) {
                             runTime = Service.startService(options, runTime)
                             runStateFlow.tryEmit(RunState.START)
+                            updateWidgetRunningState(true)
                         }
                     } ?: run {
                         val intent = VpnService.prepare(GlobalState.application)
                         if (intent != null) {
+                            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            GlobalState.application.startActivity(intent)
                             return@launch
                         }
                         runTime = Service.startService(options, runTime)
                         runStateFlow.tryEmit(RunState.START)
+                        updateWidgetRunningState(true)
                     }
                 } finally {
                     if (runStateFlow.value == RunState.PENDING) {
@@ -191,12 +219,25 @@ object State {
                     runStateFlow.tryEmit(RunState.PENDING)
                     runTime = Service.stopService()
                     runStateFlow.tryEmit(RunState.STOP)
+                    updateWidgetRunningState(false)
                 } finally {
                     if (runStateFlow.value == RunState.PENDING) {
                         runStateFlow.tryEmit(RunState.START)
                     }
                 }
             }
+        }
+    }
+
+    private fun updateWidgetRunningState(isStart: Boolean) {
+        val context = GlobalState.application
+        val currentState = WidgetDataStore.getState(context)
+        WidgetDataStore.saveState(context, currentState.copy(isStart = isStart))
+        val appWidgetManager = AppWidgetManager.getInstance(context)
+        val componentName = ComponentName(context, WidgetProvider::class.java)
+        val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
+        for (appWidgetId in appWidgetIds) {
+            WidgetProvider.updateWidget(context, appWidgetManager, appWidgetId)
         }
     }
 }

--- a/android/app/src/main/kotlin/com/follow/clash/TempActivity.kt
+++ b/android/app/src/main/kotlin/com/follow/clash/TempActivity.kt
@@ -1,16 +1,22 @@
 package com.follow.clash
 
 import android.app.Activity
+import android.app.AlertDialog
+import android.content.Intent
 import android.os.Bundle
 import com.follow.clash.common.QuickAction
 import com.follow.clash.common.action
+import com.google.gson.Gson
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import java.util.Locale
 
 class TempActivity : Activity(),
     CoroutineScope by CoroutineScope(SupervisorJob() + Dispatchers.Default) {
+    private val gson = Gson()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         when (intent.action) {
@@ -18,20 +24,53 @@ class TempActivity : Activity(),
                 launch {
                     State.handleStartServiceAction()
                 }
+                finish()
             }
 
             QuickAction.STOP.action -> {
                 launch {
                     State.handleStopServiceAction()
                 }
+                finish()
             }
 
             QuickAction.TOGGLE.action -> {
                 launch {
                     State.handleToggleAction()
                 }
+                finish()
+            }
+
+            QuickAction.SELECT_PROXY.action -> {
+                showProxySelector()
             }
         }
-        finish()
+    }
+
+    private fun showProxySelector() {
+        val state = WidgetDataStore.getState(this)
+        val proxyNames = try {
+            gson.fromJson(state.proxyNames, Array<String>::class.java)?.toList() ?: emptyList()
+        } catch (_: Exception) {
+            emptyList<String>()
+        }
+        if (proxyNames.isEmpty()) {
+            finish()
+            return
+        }
+        val items = proxyNames.toTypedArray()
+        val builder = AlertDialog.Builder(this)
+        builder.setTitle(if (Locale.getDefault().language == "zh") "选择节点" else "Select Proxy")
+        builder.setItems(items) { _, which ->
+            val selected = items[which]
+            val resultIntent = Intent(this, WidgetProvider::class.java).apply {
+                action = WidgetProvider.ACTION_SELECT_PROXY
+                putExtra("selectedProxy", selected)
+            }
+            sendBroadcast(resultIntent)
+            finish()
+        }
+        builder.setOnCancelListener { finish() }
+        builder.show()
     }
 }

--- a/android/app/src/main/kotlin/com/follow/clash/WidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/follow/clash/WidgetProvider.kt
@@ -1,0 +1,280 @@
+package com.follow.clash
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.content.Intent
+import android.content.res.Configuration
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import android.widget.RemoteViews
+import com.follow.clash.common.Components
+import com.follow.clash.common.GlobalState
+import com.follow.clash.common.QuickAction
+import com.follow.clash.common.action
+import com.follow.clash.common.intent
+import com.follow.clash.common.quickIntent
+import kotlinx.coroutines.launch
+import com.follow.clash.plugins.WidgetPlugin
+import com.google.gson.Gson
+import java.util.Locale
+
+data class WidgetState(
+    val isStart: Boolean = false,
+    val mode: String = "rule",
+    val groupName: String = "",
+    val nodeName: String = "",
+    val upSpeed: Number = 0,
+    val downSpeed: Number = 0,
+    val proxyNames: String = "",
+)
+
+object WidgetDataStore {
+    private const val PREFS_NAME = "widget_prefs"
+    private const val KEY_STATE = "widget_state"
+    private const val KEY_LAST_UPDATE = "widget_last_update"
+    private const val STALE_TIMEOUT_MS = 300_000L
+    private val gson = Gson()
+
+    fun getState(context: Context): WidgetState {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val lastUpdate = prefs.getLong(KEY_LAST_UPDATE, 0)
+        if (System.currentTimeMillis() - lastUpdate > STALE_TIMEOUT_MS) {
+            return WidgetState()
+        }
+        val json = prefs.getString(KEY_STATE, null) ?: return WidgetState()
+        return try {
+            gson.fromJson(json, WidgetState::class.java)
+        } catch (_: Exception) {
+            WidgetState()
+        }
+    }
+
+    fun saveState(context: Context, state: WidgetState) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit()
+            .putString(KEY_STATE, gson.toJson(state))
+            .putLong(KEY_LAST_UPDATE, System.currentTimeMillis())
+            .apply()
+    }
+
+    fun saveStateAsync(context: Context, state: WidgetState) {
+        GlobalState.launch {
+            saveState(context, state)
+        }
+    }
+}
+
+class WidgetProvider : AppWidgetProvider() {
+
+    companion object {
+        const val ACTION_CYCLE_MODE = "com.follow.clash.action.CYCLE_MODE"
+        const val ACTION_CYCLE_NODE = "com.follow.clash.action.CYCLE_NODE"
+        const val ACTION_SELECT_PROXY = "com.follow.clash.action.SELECT_PROXY"
+        const val EXTRA_MODE = "current_mode"
+
+        private fun isChinese(): Boolean {
+            return Locale.getDefault().language == "zh"
+        }
+
+        private fun formatSpeed(bytes: Number): String {
+            val b = bytes.toDouble()
+            return when {
+                b >= 1_000_000 -> String.format("%.1f MB/s", b / 1_000_000)
+                b >= 1_000 -> String.format("%.1f KB/s", b / 1_000)
+                else -> String.format("%.0f B/s", b)
+            }
+        }
+
+        fun buildModeIntent(context: Context): Intent {
+            val intent = Intent(context, WidgetProvider::class.java)
+            intent.action = ACTION_CYCLE_MODE
+            intent.putExtra(EXTRA_MODE, WidgetDataStore.getState(context).mode)
+            return intent
+        }
+
+        fun buildNodeIntent(context: Context): Intent {
+            return QuickAction.SELECT_PROXY.quickIntent
+        }
+
+        fun updateWidget(context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int, chartBytes: ByteArray? = null) {
+            val state = WidgetDataStore.getState(context)
+            val views = RemoteViews(context.packageName, R.layout.widget_layout)
+            val cn = isChinese()
+
+            // Dark mode
+            val isDarkMode = (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+            if (isDarkMode) {
+                views.setInt(R.id.widget_root, "setBackgroundResource", R.drawable.widget_bg_dark)
+                views.setInt(R.id.status_row, "setBackgroundResource", R.drawable.widget_ripple_dark)
+                views.setInt(R.id.mode_row, "setBackgroundResource", R.drawable.widget_ripple_dark)
+                views.setInt(R.id.node_row, "setBackgroundResource", R.drawable.widget_ripple_dark)
+                views.setTextColor(R.id.status_text, Color.parseColor("#FFE0E0E0"))
+                views.setTextColor(R.id.mode_text, Color.parseColor("#FFE0E0E0"))
+                views.setTextColor(R.id.node_text, Color.parseColor("#FFE0E0E0"))
+                views.setTextColor(R.id.mode_title, Color.parseColor("#8AFFFFFF"))
+                views.setTextColor(R.id.node_title, Color.parseColor("#8AFFFFFF"))
+                views.setTextColor(R.id.traffic_text, Color.parseColor("#8AFFFFFF"))
+                views.setTextColor(R.id.mode_chevron, Color.parseColor("#8AFFFFFF"))
+                views.setTextColor(R.id.node_chevron, Color.parseColor("#8AFFFFFF"))
+                views.setInt(R.id.divider1, "setBackgroundColor", Color.parseColor("#1AFFFFFF"))
+                views.setInt(R.id.divider2, "setBackgroundColor", Color.parseColor("#1AFFFFFF"))
+            } else {
+                views.setTextColor(R.id.status_text, Color.BLACK)
+                views.setTextColor(R.id.mode_text, Color.BLACK)
+                views.setTextColor(R.id.node_text, Color.BLACK)
+                views.setTextColor(R.id.mode_title, Color.parseColor("#8A000000"))
+                views.setTextColor(R.id.node_title, Color.parseColor("#8A000000"))
+                views.setTextColor(R.id.traffic_text, Color.parseColor("#8A000000"))
+                views.setTextColor(R.id.mode_chevron, Color.parseColor("#8A000000"))
+                views.setTextColor(R.id.node_chevron, Color.parseColor("#8A000000"))
+                views.setInt(R.id.divider1, "setBackgroundColor", Color.parseColor("#1A000000"))
+                views.setInt(R.id.divider2, "setBackgroundColor", Color.parseColor("#1A000000"))
+            }
+
+            // Status
+            val statusText = if (state.isStart) {
+                if (cn) "运行中" else "Running"
+            } else {
+                if (cn) "已停止" else "Stopped"
+            }
+            views.setTextViewText(R.id.status_text, statusText)
+            views.setInt(
+                R.id.status_icon,
+                "setBackgroundResource",
+                if (state.isStart) R.drawable.status_dot else R.drawable.status_dot_stopped
+            )
+
+            // Power icon
+            val powerIcon = if (state.isStart) R.drawable.ic_power_active else R.drawable.ic_power_inactive
+            views.setImageViewResource(R.id.toggle_button, powerIcon)
+
+            // Traffic
+            val downText = "↓ ${formatSpeed(state.downSpeed)}"
+            val upText = "↑ ${formatSpeed(state.upSpeed)}"
+            views.setTextViewText(R.id.traffic_text, "$downText  $upText")
+            if (chartBytes != null) {
+                val bitmap = BitmapFactory.decodeByteArray(chartBytes, 0, chartBytes.size)
+                if (bitmap != null) {
+                    views.setImageViewBitmap(R.id.traffic_chart, bitmap)
+                }
+            }
+
+            // Mode
+            val modeLabel = when (state.mode.lowercase(Locale.ROOT)) {
+                "rule" -> if (cn) "规则" else "Rule"
+                "global" -> if (cn) "全局" else "Global"
+                "direct" -> if (cn) "直连" else "Direct"
+                else -> state.mode.replaceFirstChar { it.uppercase() }
+            }
+            val modeTitle = if (cn) "模式" else "Mode"
+            views.setTextViewText(R.id.mode_title, modeTitle)
+            views.setTextViewText(R.id.mode_text, modeLabel)
+
+            // Node
+            val nodeTitle = if (cn) "节点" else "Node"
+            views.setTextViewText(R.id.node_title, nodeTitle)
+            val nodeLabel = if (state.nodeName.isNotEmpty()) state.nodeName else if (cn) "自动" else "Auto"
+            views.setTextViewText(R.id.node_text, nodeLabel)
+
+            // Click handlers - Toggle (Start/Stop)
+            val toggleIntent = if (state.isStart) {
+                QuickAction.STOP.quickIntent
+            } else {
+                QuickAction.START.quickIntent
+            }
+            val togglePendingIntent = PendingIntent.getActivity(
+                context,
+                0,
+                toggleIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+            views.setOnClickPendingIntent(R.id.status_row, togglePendingIntent)
+            views.setOnClickPendingIntent(R.id.toggle_button, togglePendingIntent)
+
+            // Click handlers - Mode (cycle mode via broadcast)
+            val modeIntent = buildModeIntent(context)
+            val modePendingIntent = PendingIntent.getBroadcast(
+                context,
+                1,
+                modeIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+            views.setOnClickPendingIntent(R.id.mode_row, modePendingIntent)
+
+            // Click handlers - Node (open proxy selection dialog)
+            val nodeIntent = buildNodeIntent(context)
+            val nodePendingIntent = PendingIntent.getActivity(
+                context,
+                3,
+                nodeIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+            views.setOnClickPendingIntent(R.id.node_row, nodePendingIntent)
+
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        for (appWidgetId in appWidgetIds) {
+            updateWidget(context, appWidgetManager, appWidgetId)
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        when (intent.action) {
+            ACTION_CYCLE_MODE -> handleCycleMode(context)
+            ACTION_CYCLE_NODE -> handleCycleNode(context)
+            ACTION_SELECT_PROXY -> {
+                val proxyName = intent.getStringExtra("selectedProxy") ?: return
+                handleSelectProxy(context, proxyName)
+            }
+        }
+    }
+
+    private fun handleCycleMode(context: Context) {
+        val flutterEngine = State.flutterEngine
+        if (flutterEngine != null) {
+            val widgetPlugin = flutterEngine.plugin<WidgetPlugin>()
+            widgetPlugin?.handleCycleMode()
+        } else {
+            val intent = Components.MAIN_ACTIVITY.intent.apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            }
+            context.startActivity(intent)
+        }
+    }
+
+    private fun handleCycleNode(context: Context) {
+        val flutterEngine = State.flutterEngine
+        if (flutterEngine != null) {
+            val widgetPlugin = flutterEngine.plugin<WidgetPlugin>()
+            widgetPlugin?.handleCycleNode()
+        } else {
+            val intent = Components.MAIN_ACTIVITY.intent.apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            }
+            context.startActivity(intent)
+        }
+    }
+
+    private fun handleSelectProxy(context: Context, proxyName: String) {
+        val flutterEngine = State.flutterEngine
+        if (flutterEngine != null) {
+            val widgetPlugin = flutterEngine.plugin<WidgetPlugin>()
+            widgetPlugin?.handleSelectProxy(proxyName)
+        } else {
+            val intent = Components.MAIN_ACTIVITY.intent.apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            }
+            context.startActivity(intent)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/follow/clash/plugins/WidgetPlugin.kt
+++ b/android/app/src/main/kotlin/com/follow/clash/plugins/WidgetPlugin.kt
@@ -1,0 +1,73 @@
+package com.follow.clash.plugins
+
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import com.follow.clash.WidgetDataStore
+import com.follow.clash.WidgetProvider
+import com.follow.clash.WidgetState
+import com.follow.clash.common.Components
+import com.follow.clash.common.GlobalState
+import com.google.gson.Gson
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+class WidgetPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
+    private lateinit var channel: MethodChannel
+    private val gson = Gson()
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel = MethodChannel(
+            binding.binaryMessenger, "${Components.PACKAGE_NAME}/widget"
+        )
+        channel.setMethodCallHandler(this)
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel.setMethodCallHandler(null)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "updateWidget" -> {
+                @Suppress("UNCHECKED_CAST")
+                val data = call.arguments as? Map<String, Any?>
+                if (data != null) {
+                    handleUpdateWidget(data)
+                }
+                result.success(true)
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    fun handleCycleMode() {
+        channel.invokeMethod("cycleMode", null)
+    }
+
+    fun handleCycleNode() {
+        channel.invokeMethod("cycleNode", null)
+    }
+
+    fun handleSelectProxy(proxyName: String) {
+        channel.invokeMethod("selectProxy", proxyName)
+    }
+
+    private fun handleUpdateWidget(data: Map<String, Any?>) {
+        try {
+            val chartBytes = data["chartBytes"] as? ByteArray
+            val dataWithoutChart = data.filterKeys { it != "chartBytes" }
+            val jsonString = gson.toJson(dataWithoutChart)
+            val state = gson.fromJson(jsonString, WidgetState::class.java)
+            val context = GlobalState.application
+            WidgetDataStore.saveState(context, state)
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+            val componentName = ComponentName(context, WidgetProvider::class.java)
+            val appWidgetIds = appWidgetManager.getAppWidgetIds(componentName)
+            for (appWidgetId in appWidgetIds) {
+                WidgetProvider.updateWidget(context, appWidgetManager, appWidgetId, chartBytes)
+            }
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/android/app/src/main/res/drawable/ic_power.xml
+++ b/android/app/src/main/res/drawable/ic_power.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF6666FB"
+        android:pathData="M13,3h-2v10h2V3zM17.83,5.17l-1.42,1.42C17.99,7.86 19,9.81 19,12c0,3.87 -3.13,7 -7,7s-7,-3.13 -7,-7c0,-2.19 1.01,-4.14 2.59,-5.42L6.17,5.17C4.23,6.82 3,9.26 3,12c0,4.97 4.03,9 9,9s9,-4.03 9,-9c0,-2.74 -1.23,-5.18 -3.17,-6.83z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_power_active.xml
+++ b/android/app/src/main/res/drawable/ic_power_active.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF6666FB"
+        android:pathData="M13,3h-2v10h2V3zM17.83,5.17l-1.42,1.42C17.99,7.86 19,9.81 19,12c0,3.87 -3.13,7 -7,7s-7,-3.13 -7,-7c0,-2.19 1.01,-4.14 2.59,-5.42L6.17,5.17C4.23,6.82 3,9.26 3,12c0,4.97 4.03,9 9,9s9,-4.03 9,-9c0,-2.74 -1.23,-5.18 -3.17,-6.83z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_power_inactive.xml
+++ b/android/app/src/main/res/drawable/ic_power_inactive.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF9E9E9E"
+        android:pathData="M13,3h-2v10h2V3zM17.83,5.17l-1.42,1.42C17.99,7.86 19,9.81 19,12c0,3.87 -3.13,7 -7,7s-7,-3.13 -7,-7c0,-2.19 1.01,-4.14 2.59,-5.42L6.17,5.17C4.23,6.82 3,9.26 3,12c0,4.97 4.03,9 9,9s9,-4.03 9,-9c0,-2.74 -1.23,-5.18 -3.17,-6.83z" />
+</vector>

--- a/android/app/src/main/res/drawable/status_dot.xml
+++ b/android/app/src/main/res/drawable/status_dot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#FF4CAF50" />
+    <size android:width="12dp" android:height="12dp" />
+</shape>

--- a/android/app/src/main/res/drawable/status_dot_stopped.xml
+++ b/android/app/src/main/res/drawable/status_dot_stopped.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#FF9E9E9E" />
+    <size android:width="12dp" android:height="12dp" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_bg.xml
+++ b/android/app/src/main/res/drawable/widget_bg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FFF2F2F2" />
+    <corners android:radius="16dp" />
+    <stroke
+        android:width="0.5dp"
+        android:color="#1A000000" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_bg_dark.xml
+++ b/android/app/src/main/res/drawable/widget_bg_dark.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#FF2D2D2D" />
+    <corners android:radius="16dp" />
+    <stroke
+        android:width="0.5dp"
+        android:color="#1AFFFFFF" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_ripple.xml
+++ b/android/app/src/main/res/drawable/widget_ripple.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#0A000000" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</selector>

--- a/android/app/src/main/res/drawable/widget_ripple_dark.xml
+++ b/android/app/src/main/res/drawable/widget_ripple_dark.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="#1AFFFFFF" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</selector>

--- a/android/app/src/main/res/layout/widget_layout.xml
+++ b/android/app/src/main/res/layout/widget_layout.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="10dp"
+    android:clipToPadding="false"
+    android:background="@drawable/widget_bg">
+
+    <!-- Status Row -->
+    <LinearLayout
+        android:id="@+id/status_row"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="@drawable/widget_ripple">
+
+        <TextView
+            android:id="@+id/status_icon"
+            android:layout_width="10dp"
+            android:layout_height="10dp"
+            android:layout_marginEnd="6dp"
+            android:background="@drawable/status_dot"
+            android:importantForAccessibility="no" />
+
+        <TextView
+            android:id="@+id/status_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Running"
+            android:textSize="13sp"
+            android:textStyle="bold"
+            android:textColor="@android:color/black" />
+
+        <ImageButton
+            android:id="@+id/toggle_button"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:src="@drawable/ic_power"
+            android:scaleType="fitCenter"
+            android:background="@android:color/transparent"
+            android:contentDescription="Toggle"
+            android:clickable="true"
+            android:focusable="true" />
+    </LinearLayout>
+
+    <!-- Traffic Row -->
+    <LinearLayout
+        android:id="@+id/traffic_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center">
+
+        <ImageView
+            android:id="@+id/traffic_chart"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:scaleType="fitXY"
+            android:importantForAccessibility="no" />
+
+        <TextView
+            android:id="@+id/traffic_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="↓ 0 B/s  ↑ 0 B/s"
+            android:textSize="9sp"
+            android:textColor="#8A000000"
+            android:gravity="center"
+            android:paddingBottom="1dp" />
+    </LinearLayout>
+
+    <!-- Divider -->
+    <TextView
+        android:id="@+id/divider1"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:background="#1A000000"
+        android:importantForAccessibility="no" />
+
+    <!-- Mode Row -->
+    <LinearLayout
+        android:id="@+id/mode_row"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="@drawable/widget_ripple">
+
+        <TextView
+            android:id="@+id/mode_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Mode"
+            android:textSize="10sp"
+            android:textColor="#8A000000" />
+
+        <TextView
+            android:id="@+id/mode_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Rule"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            android:textColor="@android:color/black"
+            android:gravity="end" />
+
+        <TextView
+            android:layout_width="14dp"
+            android:layout_height="14dp"
+            android:id="@+id/mode_chevron"
+            android:text="›"
+            android:textSize="16sp"
+            android:textColor="#8A000000"
+            android:gravity="center"
+            android:importantForAccessibility="no" />
+    </LinearLayout>
+
+    <!-- Divider -->
+    <TextView
+        android:id="@+id/divider2"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:background="#1A000000"
+        android:importantForAccessibility="no" />
+
+    <!-- Node Row -->
+    <LinearLayout
+        android:id="@+id/node_row"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="@drawable/widget_ripple">
+
+        <TextView
+            android:id="@+id/node_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Node"
+            android:textSize="10sp"
+            android:textColor="#8A000000" />
+
+        <TextView
+            android:id="@+id/node_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Auto"
+            android:textSize="12sp"
+            android:textColor="@android:color/black"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:gravity="end" />
+
+        <TextView
+            android:id="@+id/node_chevron"
+            android:layout_width="14dp"
+            android:layout_height="14dp"
+            android:text="›"
+            android:textSize="16sp"
+            android:textColor="#8A000000"
+            android:gravity="center"
+            android:importantForAccessibility="no" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/android/app/src/main/res/xml/widget_info.xml
+++ b/android/app/src/main/res/xml/widget_info.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="146dp"
+    android:minHeight="146dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/widget_layout"
+    android:resizeMode="none"
+    android:widgetCategory="home_screen" />

--- a/android/common/src/main/java/com/follow/clash/common/Enums.kt
+++ b/android/common/src/main/java/com/follow/clash/common/Enums.kt
@@ -7,6 +7,7 @@ enum class QuickAction {
     STOP,
     START,
     TOGGLE,
+    SELECT_PROXY,
 }
 
 enum class BroadcastAction {

--- a/lib/application.dart
+++ b/lib/application.dart
@@ -7,6 +7,7 @@ import 'package:fl_clash/core/core.dart';
 import 'package:fl_clash/l10n/l10n.dart';
 import 'package:fl_clash/manager/hotkey_manager.dart';
 import 'package:fl_clash/manager/manager.dart';
+import 'package:fl_clash/manager/widget_manager.dart';
 import 'package:fl_clash/plugins/app.dart';
 import 'package:fl_clash/providers/providers.dart';
 import 'package:fl_clash/state.dart';
@@ -97,7 +98,7 @@ class ApplicationState extends ConsumerState<Application> {
         ),
       );
     }
-    return AndroidManager(child: TileManager(child: child));
+    return AndroidManager(child: TileManager(child: WidgetManager(child: child)));
   }
 
   Widget _buildState({required Widget child}) {

--- a/lib/manager/widget_manager.dart
+++ b/lib/manager/widget_manager.dart
@@ -1,0 +1,257 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:fl_clash/common/app_localizations.dart';
+import 'package:fl_clash/common/iterable.dart';
+import 'package:fl_clash/models/common.dart';
+import 'package:fl_clash/plugins/app.dart';
+import 'package:fl_clash/plugins/widget.dart';
+import 'package:fl_clash/providers/providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class WidgetManager extends ConsumerStatefulWidget {
+  final Widget child;
+
+  const WidgetManager({super.key, required this.child});
+
+  @override
+  ConsumerState<WidgetManager> createState() => _WidgetManagerState();
+}
+
+class _WidgetManagerState extends ConsumerState<WidgetManager>
+    with WidgetListener {
+  String _lastMode = 'rule';
+  String _lastNodeName = '';
+  String _lastGroupName = '';
+  num _lastUpSpeed = 0;
+  num _lastDownSpeed = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(isStartProvider, (prev, next) {
+      _updateWidget();
+    });
+    ref.listen(patchClashConfigProvider, (prev, next) {
+      final newMode = next.mode.name;
+      if (newMode != _lastMode) {
+        _lastMode = newMode;
+        _updateWidget();
+      }
+    });
+    ref.listen(groupsProvider, (prev, next) {
+      _updateNodeInfo(next);
+    });
+    ref.listen(trafficsProvider, (prev, next) {
+      final traffic = next.list.safeLast(const Traffic());
+      if (traffic.up != _lastUpSpeed || traffic.down != _lastDownSpeed) {
+        _lastUpSpeed = traffic.up;
+        _lastDownSpeed = traffic.down;
+        _updateWidget();
+      }
+    });
+    return widget.child;
+  }
+
+  String _findNodeName(List<Group> groups) {
+    if (groups.isEmpty) return '';
+    final ignored = {'DIRECT', 'REJECT', 'GLOBAL', 'PASS', 'COMPATIBLE'};
+    final target = groups.cast<Group?>().firstWhere(
+      (g) =>
+          g!.now != null &&
+          g.now!.isNotEmpty &&
+          !ignored.contains(g.now!.toUpperCase()),
+      orElse: () => null,
+    );
+    return target?.now ?? groups.first.now ?? '';
+  }
+
+  String _findGroupName(List<Group> groups) {
+    if (groups.isEmpty) return '';
+    final ignored = {'DIRECT', 'REJECT', 'GLOBAL', 'PASS', 'COMPATIBLE'};
+    final target = groups.cast<Group?>().firstWhere(
+      (g) =>
+          g!.now != null &&
+          g.now!.isNotEmpty &&
+          !ignored.contains(g.now!.toUpperCase()),
+      orElse: () => null,
+    );
+    return target?.name ?? groups.first.name;
+  }
+
+  void _updateNodeInfo(List<Group> groups) {
+    final nodeName = _findNodeName(groups);
+    final groupName = _findGroupName(groups);
+    if (nodeName != _lastNodeName || groupName != _lastGroupName) {
+      _lastNodeName = nodeName;
+      _lastGroupName = groupName;
+      _updateWidget();
+    }
+  }
+
+  void _updateWidget() {
+    final isStart = ref.read(isStartProvider);
+    final mode = ref.read(
+      patchClashConfigProvider.select((state) => state.mode.name),
+    );
+    final groups = ref.read(groupsProvider);
+    final traffic = ref.read(trafficsProvider).list.safeLast(const Traffic());
+    final nodeName = _findNodeName(groups);
+    final groupName = _findGroupName(groups);
+
+    final dynamicGroup = groups.getGroup(groupName);
+    final proxyNames = dynamicGroup != null
+        ? jsonEncode(dynamicGroup.all.map((p) => p.name).toList())
+        : '';
+
+    widgetChannel?.updateWidget(
+      isStart: isStart,
+      mode: mode,
+      nodeName: nodeName,
+      groupName: groupName,
+      upSpeed: traffic.up,
+      downSpeed: traffic.down,
+      proxyNames: proxyNames,
+    );
+    _updateChart();
+  }
+
+  Future<void> _updateChart() async {
+    final isStart = ref.read(isStartProvider);
+    if (!isStart) return;
+    final now = DateTime.now();
+    if (now.difference(_lastChartTime) < const Duration(seconds: 3)) return;
+    _lastChartTime = now;
+    final trafficList = ref.read(trafficsProvider).list.toList();
+    final chartBytes = await _generateChart(trafficList);
+    if (!mounted || chartBytes == null) return;
+    widgetChannel?.updateWidget(
+      isStart: ref.read(isStartProvider),
+      mode: ref.read(patchClashConfigProvider.select((s) => s.mode.name)),
+      nodeName: _lastNodeName,
+      groupName: _lastGroupName,
+      upSpeed: ref.read(trafficsProvider).list.safeLast(const Traffic()).up,
+      downSpeed: ref.read(trafficsProvider).list.safeLast(const Traffic()).down,
+      proxyNames: jsonEncode(
+        ref.read(groupsProvider).getGroup(_lastGroupName)?.all
+                .map((p) => p.name).toList() ?? [],
+      ),
+      chartBytes: chartBytes,
+    );
+  }
+
+  @override
+  void onCycleMode() {
+    ref.read(commonActionProvider.notifier).updateMode();
+    app?.tip(currentAppLocalizations.toggle);
+    super.onCycleMode();
+  }
+
+  @override
+  void onCycleNode() {
+    final groups = ref.read(groupsProvider);
+    final groupName = _lastGroupName;
+    if (groupName.isEmpty) return;
+
+    final group = groups.getGroup(groupName);
+    if (group == null || group.all.isEmpty) return;
+
+    final current = _lastNodeName.isNotEmpty ? _lastNodeName : group.now;
+    final currentIndex = group.all.indexWhere((p) => p.name == current);
+    final nextIndex = (currentIndex + 1) % group.all.length;
+    final nextProxy = group.all[nextIndex];
+    if (nextProxy.name == current) return;
+
+    ref.read(profilesActionProvider.notifier)
+        .updateCurrentSelectedMap(groupName, nextProxy.name);
+    ref.read(proxiesActionProvider.notifier)
+        .changeProxyDebounce(groupName, nextProxy.name);
+    app?.tip(nextProxy.name);
+    super.onCycleNode();
+  }
+
+  @override
+  void onSelectProxy(String proxyName) {
+    final groups = ref.read(groupsProvider);
+    final groupName = _lastGroupName;
+    if (groupName.isEmpty) return;
+
+    ref.read(profilesActionProvider.notifier)
+        .updateCurrentSelectedMap(groupName, proxyName);
+    ref.read(proxiesActionProvider.notifier)
+        .changeProxyDebounce(groupName, proxyName);
+    app?.tip(proxyName);
+    super.onSelectProxy(proxyName);
+  }
+
+  DateTime _lastChartTime = DateTime(2000);
+  static const _chartWidth = 120;
+  static const _chartHeight = 30;
+
+  Future<Uint8List?> _generateChart(List<Traffic> trafficList) async {
+    if (trafficList.length < 2) return null;
+    final maxVal = trafficList.fold<num>(
+      1,
+      (max, t) => max > t.up + t.down ? max : t.up + t.down,
+    );
+    if (maxVal <= 0) return null;
+    final maxD = maxVal.toDouble();
+
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(recorder);
+
+    final bgPaint = Paint()..color = const Color(0x08000000);
+    canvas.drawRect(
+      Rect.fromLTWH(0, 0, _chartWidth.toDouble(), _chartHeight.toDouble()),
+      bgPaint,
+    );
+
+    final upPaint = Paint()
+      ..color = const Color(0xFF6666FB)
+      ..strokeWidth = 1.0
+      ..style = PaintingStyle.stroke;
+    final downPaint = Paint()
+      ..color = const Color(0xFF4CAF50)
+      ..strokeWidth = 1.0
+      ..style = PaintingStyle.stroke;
+
+    final n = trafficList.length;
+    final stepX = (_chartWidth - 4) / max(1, n - 1);
+
+    Path buildPath(num Function(Traffic) getValue) {
+      final path = Path();
+      for (int i = 0; i < n; i++) {
+        final x = 2.0 + i * stepX;
+        final y = (_chartHeight - 2) -
+            (getValue(trafficList[i]).toDouble() / maxD) * (_chartHeight - 4);
+        i == 0 ? path.moveTo(x, y) : path.lineTo(x, y);
+      }
+      return path;
+    }
+
+    canvas.drawPath(buildPath((t) => t.down), downPaint);
+    canvas.drawPath(buildPath((t) => t.up), upPaint);
+
+    final picture = recorder.endRecording();
+    final image = await picture.toImage(_chartWidth, _chartHeight);
+    final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+    return byteData?.buffer.asUint8List();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    widgetChannel?.addListener(this);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _updateWidget();
+    });
+  }
+
+  @override
+  void dispose() {
+    widgetChannel?.removeListener(this);
+    super.dispose();
+  }
+}

--- a/lib/plugins/widget.dart
+++ b/lib/plugins/widget.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:fl_clash/common/constant.dart';
+import 'package:fl_clash/common/system.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+abstract mixin class WidgetListener {
+  void onCycleMode() {}
+  void onCycleNode() {}
+  void onSelectProxy(String proxyName) {}
+}
+
+class WidgetChannel {
+  final MethodChannel _channel = const MethodChannel('$packageName/widget');
+
+  WidgetChannel._() {
+    _channel.setMethodCallHandler(_methodCallHandler);
+  }
+
+  static final WidgetChannel instance = WidgetChannel._();
+
+  final ObserverList<WidgetListener> _listeners = ObserverList<WidgetListener>();
+
+  Future<void> _methodCallHandler(MethodCall call) async {
+    for (final WidgetListener listener in _listeners) {
+      switch (call.method) {
+        case 'cycleMode':
+          listener.onCycleMode();
+          break;
+        case 'cycleNode':
+          listener.onCycleNode();
+          break;
+        case 'selectProxy':
+          if (call.arguments is String) {
+            listener.onSelectProxy(call.arguments as String);
+          }
+          break;
+      }
+    }
+  }
+
+  void addListener(WidgetListener listener) {
+    _listeners.add(listener);
+  }
+
+  void removeListener(WidgetListener listener) {
+    _listeners.remove(listener);
+  }
+
+  Future<void> updateWidget({
+    required bool isStart,
+    required String mode,
+    required String nodeName,
+    required String groupName,
+    required num upSpeed,
+    required num downSpeed,
+    required String proxyNames,
+    Uint8List? chartBytes,
+  }) async {
+    final data = {
+      'isStart': isStart,
+      'mode': mode,
+      'nodeName': nodeName,
+      'groupName': groupName,
+      'upSpeed': upSpeed,
+      'downSpeed': downSpeed,
+      'proxyNames': proxyNames,
+    };
+    if (chartBytes != null) {
+      data['chartBytes'] = chartBytes;
+    }
+    await _channel.invokeMethod('updateWidget', data);
+  }
+}
+
+final widgetChannel = system.isAndroid ? WidgetChannel.instance : null;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -745,10 +745,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   intl_utils:
     dependency: "direct dev"
     description:
@@ -866,10 +866,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: "direct main"
     description:
@@ -890,10 +890,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -1540,26 +1540,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.18"
   tray_manager:
     dependency: "direct main"
     description:
@@ -1685,10 +1685,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "1d774bbdf6b72a0b12122fc1560c9c2d2a67db5a4a4cc2bd8a5c990ab20e3188"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:


### PR DESCRIPTION
- 实现 2x2 小部件，支持深色主题自动适配
- 状态显示（运行中/已停止）+ 开关按钮
- 模式显示 + 点击轮换（Rule/Global/Direct）
- 节点显示 + 点击弹出选择列表
- 流量图表（曲线图）+ 速度文本
- 中文本地化
- Dart 端 WidgetManager 响应式更新
- 后台状态检测：300s 超时 + SERVICE_CREATED/DESTROYED
- 修复 Android 14+ 隐式广播问题