### PR TITLE
Fix custom Geo resource URLs

### DIFF
--- a/lib/enum/enum.dart
+++ b/lib/enum/enum.dart
@@ -336,9 +336,9 @@ enum GeoResource {
   MMDB,
   @JsonValue('asn')
   ASN,
-  @JsonValue('geo-ip')
+  @JsonValue('geoip')
   GEOIP,
-  @JsonValue('geo-site')
+  @JsonValue('geosite')
   GEOSITE;
 
   static GeoResource fromJson(String value) {
@@ -357,8 +357,8 @@ extension GeoResourceExt on GeoResource {
     return switch (this) {
       GeoResource.MMDB => 'mmdb',
       GeoResource.ASN => 'asn',
-      GeoResource.GEOIP => 'geo-ip',
-      GeoResource.GEOSITE => 'geo-site',
+      GeoResource.GEOIP => 'geoip',
+      GeoResource.GEOSITE => 'geosite',
     };
   }
 

--- a/test/models/config_test.dart
+++ b/test/models/config_test.dart
@@ -21,8 +21,8 @@ void main() {
     test('exposes lowercase GeoResource values', () {
       expect(GeoResource.MMDB.value, 'mmdb');
       expect(GeoResource.ASN.value, 'asn');
-      expect(GeoResource.GEOIP.value, 'geo-ip');
-      expect(GeoResource.GEOSITE.value, 'geo-site');
+      expect(GeoResource.GEOIP.value, 'geoip');
+      expect(GeoResource.GEOSITE.value, 'geosite');
     });
 
     test('parses current lowercase GeoResource keys from config JSON', () {
@@ -66,7 +66,7 @@ void main() {
         geoXUrl: {GeoResource.GEOIP: 'https://example.com/geoip.dat'},
       ).toJson();
 
-      expect(json['geox-url'], {'geo-ip': 'https://example.com/geoip.dat'});
+      expect(json['geox-url'], {'geoip': 'https://example.com/geoip.dat'});
     });
 
     test('converts geoXUrl map to raw config map', () {
@@ -77,7 +77,7 @@ void main() {
 
       expect(geoXUrl.raw, {
         'mmdb': 'https://example.com/mmdb',
-        'geo-site': 'https://example.com/geosite.dat',
+        'geosite': 'https://example.com/geosite.dat',
       });
     });
 


### PR DESCRIPTION
## Summary

- restore the custom Geo URL keys emitted for Mihomo from `geo-ip`/`geo-site` to `geoip`/`geosite`
- keep deserialization compatible with both the hyphenated and non-hyphenated forms
- update the existing model assertions for the corrected serialized output

## Impact

The field-name regression caused custom GEOIP and GEOSITE URLs to be written under keys Mihomo does not consume, so first-time Geo resource downloads could fall back to the default URLs instead of using the user's configured sources. This change restores the expected keys without changing MMDB or ASN handling.

This PR is intentionally limited to the custom Geo URL mapping and does not change the startup-stage Geo auto-update flow.

## Validation

- Flutter 3.44.4 / Dart 3.12.2
- `dart format lib/enum/enum.dart test/models/config_test.dart`
- `flutter analyze --no-fatal-infos` (passes with 10 pre-existing `withOpacity` info diagnostics)
- `flutter test test/models/config_test.dart` (33 tests passed)
- `flutter test --reporter expanded` (417 tests passed)

Fixes #2215
