### PR TITLE
Add proxy bypass dashboard widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ migrate_working_dir/
 .packages
 .pub-cache/
 .pub/
+.tools/
 /build/
 /dist/
 

--- a/lib/enum/enum.dart
+++ b/lib/enum/enum.dart
@@ -312,6 +312,7 @@ enum DashboardWidget {
     GridItem(crossAxisCellCount: 4, child: SystemProxyButton()),
     platforms: desktopPlatforms,
   ),
+  proxyBypass(GridItem(crossAxisCellCount: 8, child: ProxyBypass())),
   intranetIp(GridItem(crossAxisCellCount: 4, child: IntranetIP())),
   memoryInfo(GridItem(crossAxisCellCount: 4, child: MemoryInfo()));
 

--- a/lib/models/config.dart
+++ b/lib/models/config.dart
@@ -39,6 +39,7 @@ const defaultThemeProps = ThemeProps(primaryColor: defaultPrimaryColor);
 const List<DashboardWidget> defaultDashboardWidgets = [
   DashboardWidget.networkSpeed,
   DashboardWidget.systemProxyButton,
+  DashboardWidget.proxyBypass,
   DashboardWidget.tunButton,
   DashboardWidget.outboundMode,
   DashboardWidget.networkDetection,

--- a/lib/models/generated/config.g.dart
+++ b/lib/models/generated/config.g.dart
@@ -79,6 +79,7 @@ const _$DashboardWidgetEnumMap = {
   DashboardWidget.tunButton: 'tunButton',
   DashboardWidget.vpnButton: 'vpnButton',
   DashboardWidget.systemProxyButton: 'systemProxyButton',
+  DashboardWidget.proxyBypass: 'proxyBypass',
   DashboardWidget.intranetIp: 'intranetIp',
   DashboardWidget.memoryInfo: 'memoryInfo',
 };

--- a/lib/views/dashboard/widgets/intranet_ip.dart
+++ b/lib/views/dashboard/widgets/intranet_ip.dart
@@ -17,7 +17,7 @@ class IntranetIP extends StatelessWidget {
         info: Info(label: appLocalizations.intranetIP, iconData: Icons.devices),
         onPressed: () {},
         child: Container(
-          padding: baseInfoEdgeInsets.copyWith(top: 0),
+          padding: baseInfoEdgeInsets.copyWith(top: 0, bottom: 8),
           child: Column(
             mainAxisSize: MainAxisSize.max,
             mainAxisAlignment: MainAxisAlignment.end,

--- a/lib/views/dashboard/widgets/memory_info.dart
+++ b/lib/views/dashboard/widgets/memory_info.dart
@@ -60,7 +60,7 @@ class _MemoryInfoState extends State<MemoryInfo> {
             coreController.requestGc();
           },
           child: Container(
-            padding: baseInfoEdgeInsets.copyWith(top: 0),
+            padding: baseInfoEdgeInsets.copyWith(top: 0, bottom: 8),
             child: Column(
               mainAxisSize: MainAxisSize.max,
               mainAxisAlignment: MainAxisAlignment.end,

--- a/lib/views/dashboard/widgets/network_detection.dart
+++ b/lib/views/dashboard/widgets/network_detection.dart
@@ -93,7 +93,7 @@ class _NetworkDetectionState extends ConsumerState<NetworkDetection> {
               ),
             ),
             Container(
-              padding: baseInfoEdgeInsets.copyWith(top: 0),
+              padding: baseInfoEdgeInsets.copyWith(top: 0, bottom: 8),
               child: SizedBox(
                 height: globalState.measure.bodyMediumHeight + 2,
                 child: FadeThroughBox(

--- a/lib/views/dashboard/widgets/outbound_mode.dart
+++ b/lib/views/dashboard/widgets/outbound_mode.dart
@@ -40,7 +40,7 @@ class OutboundMode extends StatelessWidget {
                 iconData: Icons.call_split_sharp,
               ),
               child: Padding(
-                padding: const EdgeInsets.only(top: 12, bottom: 12),
+                padding: const EdgeInsets.only(top: 8, bottom: 8),
                 child: RadioGroup<Mode>(
                   groupValue: mode,
                   onChanged: (value) {
@@ -52,6 +52,13 @@ class OutboundMode extends StatelessWidget {
                   child: LayoutBuilder(
                     builder: (_, constraints) {
                       final maxHeight = constraints.maxHeight;
+                      final itemHeight = max(
+                        0.0,
+                        min(
+                          (maxHeight / Mode.values.length).floorToDouble() - 2,
+                          globalState.measure.bodyMediumHeight + 16,
+                        ),
+                      );
                       return Column(
                         mainAxisSize: MainAxisSize.max,
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -61,10 +68,7 @@ class OutboundMode extends StatelessWidget {
                             ListItem.radio(
                               horizontalTitleGap: 8,
                               tileTitleAlignment: ListTileTitleAlignment.center,
-                              minTileHeight: min(
-                                maxHeight / 3,
-                                globalState.measure.bodyMediumHeight + 16,
-                              ),
+                              minTileHeight: itemHeight,
                               minVerticalPadding: 0,
                               padding: EdgeInsets.only(
                                 left: 12.ap,

--- a/lib/views/dashboard/widgets/proxy_bypass.dart
+++ b/lib/views/dashboard/widgets/proxy_bypass.dart
@@ -1,0 +1,216 @@
+import 'package:fl_clash/common/common.dart';
+import 'package:fl_clash/providers/config.dart';
+import 'package:fl_clash/widgets/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ProxyBypass extends ConsumerWidget {
+  const ProxyBypass({super.key});
+
+  void _showOptions(BuildContext context) {
+    final appLocalizations = context.appLocalizations;
+    showSheet(
+      context: context,
+      builder: (_) {
+        return AdaptiveSheetScaffold(
+          title: appLocalizations.bypassDomain,
+          body: const _ProxyBypassList(),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final appLocalizations = context.appLocalizations;
+    final bypassDomain = ref.watch(
+      networkSettingProvider.select((state) => state.bypassDomain),
+    );
+    final systemProxy = system.isAndroid
+        ? ref.watch(vpnSettingProvider.select((state) => state.systemProxy))
+        : ref.watch(
+            networkSettingProvider.select((state) => state.systemProxy),
+          );
+    return SizedBox(
+      height: getWidgetHeight(1),
+      child: CommonCard(
+        onPressed: () {
+          _showOptions(context);
+        },
+        info: Info(
+          label: appLocalizations.bypassDomain,
+          iconData: Icons.alt_route,
+        ),
+        child: Container(
+          padding: baseInfoEdgeInsets.copyWith(top: 4, bottom: 8, right: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Flexible(
+                flex: 1,
+                child: TooltipText(
+                  text: Text(
+                    '${bypassDomain.length}${appLocalizations.entries}',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: context.textTheme.bodyMedium?.toLight.adjustSize(1),
+                  ),
+                ),
+              ),
+              Switch(
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                value: systemProxy,
+                onChanged: (value) {
+                  if (system.isAndroid) {
+                    ref
+                        .read(vpnSettingProvider.notifier)
+                        .update((state) => state.copyWith(systemProxy: value));
+                    return;
+                  }
+                  ref
+                      .read(networkSettingProvider.notifier)
+                      .update((state) => state.copyWith(systemProxy: value));
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ProxyBypassList extends ConsumerStatefulWidget {
+  const _ProxyBypassList();
+
+  @override
+  ConsumerState<_ProxyBypassList> createState() => _ProxyBypassListState();
+}
+
+class _ProxyBypassListState extends ConsumerState<_ProxyBypassList> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _updateItems(List<String> items) {
+    ref
+        .read(networkSettingProvider.notifier)
+        .update((state) => state.copyWith(bypassDomain: items));
+  }
+
+  String? _validate(String? value, List<String> items) {
+    final appLocalizations = context.appLocalizations;
+    final text = value?.trim() ?? '';
+    if (text.isEmpty) {
+      return appLocalizations.nullTip(appLocalizations.value);
+    }
+    if (items.contains(text)) {
+      return appLocalizations.existsTip(appLocalizations.value);
+    }
+    return null;
+  }
+
+  void _handleAdd(List<String> items) {
+    if (_formKey.currentState?.validate() != true) {
+      return;
+    }
+    final value = _controller.text.trim();
+    _updateItems([...items, value]);
+    _controller.clear();
+    _formKey.currentState?.reset();
+  }
+
+  void _handleDelete(List<String> items, String item) {
+    final nextItems = List<String>.from(items)..remove(item);
+    _updateItems(nextItems);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = context.appLocalizations;
+    final items = ref.watch(
+      networkSettingProvider.select((state) => state.bypassDomain),
+    );
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Form(
+            key: _formKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: TextFormField(
+                    controller: _controller,
+                    inputFormatters: TextInputLimits.limit(
+                      TextInputLimits.domain,
+                    ),
+                    textInputAction: TextInputAction.done,
+                    decoration: InputDecoration(
+                      border: const OutlineInputBorder(),
+                      labelText: appLocalizations.value,
+                    ),
+                    validator: (value) => _validate(value, items),
+                    onFieldSubmitted: (_) {
+                      _handleAdd(items);
+                    },
+                  ),
+                ),
+                const SizedBox(width: 8),
+                IconButton.filledTonal(
+                  tooltip: appLocalizations.add,
+                  onPressed: () {
+                    _handleAdd(items);
+                  },
+                  icon: const Icon(Icons.add),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Expanded(
+          child: items.isEmpty
+              ? NullStatus(label: appLocalizations.noData)
+              : ListView.builder(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                  itemCount: items.length,
+                  itemBuilder: (_, index) {
+                    final item = items[index];
+                    return ListTile(
+                      contentPadding: const EdgeInsets.only(left: 12, right: 4),
+                      title: TooltipText(
+                        text: Text(
+                          item,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      trailing: IconButton(
+                        tooltip: appLocalizations.delete,
+                        onPressed: () {
+                          _handleDelete(items, item);
+                        },
+                        icon: const Icon(Icons.delete_outline),
+                      ),
+                    );
+                  },
+                ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/dashboard/widgets/widgets.dart
+++ b/lib/views/dashboard/widgets/widgets.dart
@@ -2,6 +2,7 @@ export 'intranet_ip.dart';
 export 'network_detection.dart';
 export 'network_speed.dart';
 export 'outbound_mode.dart';
+export 'proxy_bypass.dart';
 export 'quick_options.dart';
 export 'traffic_usage.dart';
 export 'memory_info.dart';


### PR DESCRIPTION
## Summary
- add a dashboard card for system proxy/VPN bypass domains
- show bypass count with a system proxy switch on the card
- open an inline side sheet for quick bypass add/delete
- adjust dashboard card spacing to avoid RenderFlex overflow

## Verification
- flutter analyze --no-fatal-infos
- flutter test --reporter expanded test/models/config_test.dart test/providers/config_test.dart test/providers/app_test.dart
- launched Linux debug bundle and checked startup log for no RenderFlex overflow