### PR TITLE
fix: omit inactive TUN IPv6 from generated config

### DIFF
--- a/core/hub.go
+++ b/core/hub.go
@@ -464,6 +464,9 @@ func handleGetConfig(path string) (*config.RawConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	if !prof.IPv6 {
+		prof.Tun.Inet6Address = nil
+	}
 	return prof, nil
 }
 

--- a/core/hub_test.go
+++ b/core/hub_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHandleGetConfigOmitsTunIPv6WhenIPv6IsDisabled(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("ipv6: false\ntun:\n  enable: true\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	config, err := handleGetConfig(path)
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	if len(config.Tun.Inet6Address) != 0 {
+		t.Fatalf("tun inet6-address = %v, want no addresses when IPv6 is disabled", config.Tun.Inet6Address)
+	}
+}


### PR DESCRIPTION
## Summary
- omit tun.inet6-address from the raw config returned to FlClash when top-level ipv6 is disabled
- add a regression test covering the generated-config path

## Related issue
- Related to #1993. This change fixes the contradictory generated configuration; it does not claim to resolve every Windows TUN connectivity symptom reported in that issue.

## Rationale
Mihomo clears this address later while parsing a runtime config, but FlClash first round-trips the raw config and writes it back to YAML. Returning the inactive default at that stage produces a contradictory generated configuration: ipv6 is false while a TUN IPv6 address is present.

## Verification
The focused test is included in core/hub_test.go. The root project does not contain a Go module, so the project build workflow or CI must execute it rather than go test ./core directly.