### PR TITLE
fix(android): declare background location permission

### DIFF
--- a/plugins/wifi_ssid/android/src/main/AndroidManifest.xml
+++ b/plugins/wifi_ssid/android/src/main/AndroidManifest.xml
@@ -3,4 +3,5 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 </manifest>


### PR DESCRIPTION
## What changed

Added `android.permission.ACCESS_BACKGROUND_LOCATION` to the Android manifest of the `wifi_ssid` plugin.

## Why

FlClash's on-demand mode reads the current Wi-Fi SSID to decide whether the proxy should run. On Android 10 and later, users cannot grant “Allow all the time” location access unless the app explicitly declares `ACCESS_BACKGROUND_LOCATION`.

Without that declaration, SSID reads may return `null` after FlClash moves to the background, so Wi-Fi-based on-demand rules do not run reliably.

## Scope

This is a manifest-only change. It does not modify VPN lifecycle handling, background services, or code for other platforms. The permission is used to allow background Wi-Fi SSID access; this change does not add location-coordinate collection.

Users still need to grant “Allow all the time” location access in Android system settings. Device-specific battery restrictions or process termination may still affect background execution.

## Verification

- Confirmed the PR diff contains one added line in one file.
- Parsed the modified Android manifest successfully.
- `git diff --check` passes.
- Built an Android ARM64 release APK from the same upstream commit with this manifest change.
- Verified with `aapt2` that both `ACCESS_FINE_LOCATION` and `ACCESS_BACKGROUND_LOCATION` are present in the resulting APK.

Fixes #2233