### PR TITLE
Support connection sorting

### DIFF
--- a/lib/enum/enum.dart
+++ b/lib/enum/enum.dart
@@ -126,6 +126,16 @@ enum AccessControlMode { acceptSelected, rejectSelected }
 
 enum AccessSortType { none, name, time }
 
+enum ConnectionSortType {
+  none,
+  downloadDesc,
+  downloadAsc,
+  uploadDesc,
+  uploadAsc,
+  processAsc,
+  processDesc,
+}
+
 enum ProfileType { file, url }
 
 enum ResultType {

--- a/lib/models/common.dart
+++ b/lib/models/common.dart
@@ -132,6 +132,56 @@ extension TrackerInfoExt on TrackerInfo {
     }
     return process.trim();
   }
+
+  TrackerInfo withSpeedFrom(TrackerInfo? previous, Duration elapsed) {
+    if (previous == null || elapsed.inMilliseconds <= 0) {
+      return copyWith(downloadSpeed: 0, uploadSpeed: 0);
+    }
+    final milliseconds = elapsed.inMilliseconds;
+    final downloadDelta = (download - previous.download).clamp(0, download);
+    final uploadDelta = (upload - previous.upload).clamp(0, upload);
+    return copyWith(
+      downloadSpeed:
+          downloadDelta * Duration.millisecondsPerSecond ~/ milliseconds,
+      uploadSpeed: uploadDelta * Duration.millisecondsPerSecond ~/ milliseconds,
+    );
+  }
+}
+
+extension TrackerInfoListExt on List<TrackerInfo> {
+  List<TrackerInfo> sortedBy(ConnectionSortType sortType) {
+    if (sortType == ConnectionSortType.none) {
+      return this;
+    }
+    final sorted = List<TrackerInfo>.from(this);
+    sorted.sort((a, b) {
+      final result = switch (sortType) {
+        ConnectionSortType.none => 0,
+        ConnectionSortType.downloadDesc => (b.downloadSpeed ?? 0).compareTo(
+          a.downloadSpeed ?? 0,
+        ),
+        ConnectionSortType.downloadAsc => (a.downloadSpeed ?? 0).compareTo(
+          b.downloadSpeed ?? 0,
+        ),
+        ConnectionSortType.uploadDesc => (b.uploadSpeed ?? 0).compareTo(
+          a.uploadSpeed ?? 0,
+        ),
+        ConnectionSortType.uploadAsc => (a.uploadSpeed ?? 0).compareTo(
+          b.uploadSpeed ?? 0,
+        ),
+        ConnectionSortType.processAsc => utils.sortByChar(
+          a.metadata.process,
+          b.metadata.process,
+        ),
+        ConnectionSortType.processDesc => utils.sortByChar(
+          b.metadata.process,
+          a.metadata.process,
+        ),
+      };
+      return result != 0 ? result : b.start.compareTo(a.start);
+    });
+    return sorted;
+  }
 }
 
 String _logDateTime(dynamic _) {

--- a/lib/views/connection/connections.dart
+++ b/lib/views/connection/connections.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:fl_clash/common/common.dart';
 import 'package:fl_clash/core/controller.dart';
+import 'package:fl_clash/enum/enum.dart';
 import 'package:fl_clash/models/models.dart';
 import 'package:fl_clash/widgets/widgets.dart';
 import 'package:flutter/material.dart';
@@ -22,11 +23,47 @@ class _ConnectionsViewState extends ConsumerState<ConnectionsView> {
     const TrackerInfosState(),
   );
   final ScrollController _scrollController = ScrollController();
+  ConnectionSortType _sortType = ConnectionSortType.none;
+  DateTime? _lastUpdateTime;
 
   Timer? timer;
 
-  List<Widget> _buildActions() {
+  String _getSortLabel(BuildContext context, ConnectionSortType sortType) {
+    final appLocalizations = context.appLocalizations;
+    return switch (sortType) {
+      ConnectionSortType.none => appLocalizations.defaultText,
+      ConnectionSortType.downloadDesc => '${appLocalizations.download} ↓',
+      ConnectionSortType.downloadAsc => '${appLocalizations.download} ↑',
+      ConnectionSortType.uploadDesc => '${appLocalizations.upload} ↓',
+      ConnectionSortType.uploadAsc => '${appLocalizations.upload} ↑',
+      ConnectionSortType.processAsc => '${appLocalizations.process} ↑',
+      ConnectionSortType.processDesc => '${appLocalizations.process} ↓',
+    };
+  }
+
+  List<Widget> _buildActions(BuildContext context) {
+    final appLocalizations = context.appLocalizations;
     return [
+      PopupMenuButton<ConnectionSortType>(
+        tooltip:
+            '${appLocalizations.sort}: ${_getSortLabel(context, _sortType)}',
+        icon: const Icon(Icons.sort),
+        onSelected: (sortType) {
+          setState(() {
+            _sortType = sortType;
+          });
+        },
+        itemBuilder: (context) {
+          return [
+            for (final item in ConnectionSortType.values)
+              CheckedPopupMenuItem<ConnectionSortType>(
+                value: item,
+                checked: item == _sortType,
+                child: Text(_getSortLabel(context, item)),
+              ),
+          ];
+        },
+      ),
       IconButton(
         onPressed: () async {
           coreController.closeConnections();
@@ -67,8 +104,22 @@ class _ConnectionsViewState extends ConsumerState<ConnectionsView> {
   }
 
   Future<void> _updateConnections() async {
+    final trackerInfos = await coreController.getConnections();
+    final updateTime = DateTime.now();
+    final previousUpdateTime = _lastUpdateTime;
+    final previousById = {
+      for (final item in _connectionsStateNotifier.value.trackerInfos)
+        item.id: item,
+    };
+    final elapsed = previousUpdateTime == null
+        ? Duration.zero
+        : updateTime.difference(previousUpdateTime);
+    final trackerInfosWithSpeed = trackerInfos.map((item) {
+      return item.withSpeedFrom(previousById[item.id], elapsed);
+    }).toList();
+    _lastUpdateTime = updateTime;
     _connectionsStateNotifier.value = _connectionsStateNotifier.value.copyWith(
-      trackerInfos: await coreController.getConnections(),
+      trackerInfos: trackerInfosWithSpeed,
     );
   }
 
@@ -93,11 +144,11 @@ class _ConnectionsViewState extends ConsumerState<ConnectionsView> {
       title: appLocalizations.connections,
       onKeywordsUpdate: _onKeywordsUpdate,
       searchState: AppBarSearchState(onSearch: _onSearch),
-      actions: _buildActions(),
+      actions: _buildActions(context),
       body: ValueListenableBuilder<TrackerInfosState>(
         valueListenable: _connectionsStateNotifier,
         builder: (context, state, _) {
-          final connections = state.list;
+          final connections = state.list.sortedBy(_sortType);
           if (connections.isEmpty) {
             return NullStatus(
               label: appLocalizations.nullTip(appLocalizations.connections),

--- a/test/models/common_test.dart
+++ b/test/models/common_test.dart
@@ -76,6 +76,77 @@ void main() {
       expect(trackerInfo.desc, 'tcp://example.com/1.1.1.1:443');
       expect(trackerInfo.progressText, 'Browser(501)');
     });
+
+    test('calculates speeds from consecutive snapshots', () {
+      final start = DateTime(2026);
+      final previous = TrackerInfo(
+        id: '1',
+        upload: 100,
+        download: 200,
+        start: start,
+        metadata: const Metadata(process: 'Browser'),
+        chains: const [],
+        rule: 'MATCH',
+        rulePayload: '',
+      );
+      final current = previous.copyWith(upload: 400, download: 800);
+
+      final result = current.withSpeedFrom(
+        previous,
+        const Duration(milliseconds: 1500),
+      );
+
+      expect(result.uploadSpeed, 200);
+      expect(result.downloadSpeed, 400);
+      expect(current.withSpeedFrom(null, Duration.zero).uploadSpeed, 0);
+    });
+
+    test('sorts connections by speed and process', () {
+      final start = DateTime(2026);
+      TrackerInfo connection(
+        String id,
+        String process,
+        int uploadSpeed,
+        int downloadSpeed,
+      ) {
+        return TrackerInfo(
+          id: id,
+          start: start.add(Duration(seconds: int.parse(id))),
+          metadata: Metadata(process: process),
+          chains: const [],
+          rule: 'MATCH',
+          rulePayload: '',
+          uploadSpeed: uploadSpeed,
+          downloadSpeed: downloadSpeed,
+        );
+      }
+
+      final connections = [
+        connection('1', 'Zulu', 10, 30),
+        connection('2', 'alpha', 30, 20),
+        connection('3', 'Bravo', 20, 10),
+      ];
+
+      expect(
+        connections
+            .sortedBy(ConnectionSortType.downloadDesc)
+            .map((item) => item.id),
+        ['1', '2', '3'],
+      );
+      expect(
+        connections
+            .sortedBy(ConnectionSortType.uploadAsc)
+            .map((item) => item.id),
+        ['1', '3', '2'],
+      );
+      expect(
+        connections
+            .sortedBy(ConnectionSortType.processAsc)
+            .map((item) => item.id),
+        ['2', '3', '1'],
+      );
+      expect(connections.sortedBy(ConnectionSortType.none), same(connections));
+    });
   });
 
   group('TrafficExt', () {


### PR DESCRIPTION
## Summary

Add sorting controls to the connections page for easier inspection of active connections.

## Changes

- Add a sorting menu to the connections page toolbar
- Support sorting by upload speed in ascending or descending order
- Support sorting by download speed in ascending or descending order
- Support sorting by process name in ascending or descending order
- Calculate connection speed from traffic deltas between consecutive snapshots
- Preserve the original connection order when the default option is selected
- Reuse existing localized labels for sorting options
- Add tests for speed calculation and connection ordering

## Verification

- Passed the complete Flutter test suite with 419 tests
- Passed targeted Flutter analysis with no issues
- Verified the Linux release and deb package builds successfully

Closes #1725