### PR TITLE
Fix unlimited subscription info display

### DIFF
--- a/lib/widgets/subscription_info_view.dart
+++ b/lib/widgets/subscription_info_view.dart
@@ -12,13 +12,10 @@ class SubscriptionInfoView extends StatelessWidget {
     if (subscriptionInfo == null) {
       return Container();
     }
-    if (subscriptionInfo?.total == 0) {
-      return Container();
-    }
+
     final use = subscriptionInfo!.upload + subscriptionInfo!.download;
     final total = subscriptionInfo!.total;
-    final progress = use / total;
-
+    final progress = total == 0 ? 0.0 : use / total;
     final useShow = use.traffic.show;
     final totalShow = total.traffic.show;
     final expireShow =
@@ -27,17 +24,22 @@ class SubscriptionInfoView extends StatelessWidget {
             subscriptionInfo!.expire * 1000,
           ).show
         : context.appLocalizations.infiniteTime;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        LinearProgressIndicator(
-          minHeight: 6,
-          value: progress,
-          backgroundColor: context.colorScheme.primary.opacity15,
-        ),
-        const SizedBox(height: 8),
+        if (total != 0) ...[
+          LinearProgressIndicator(
+            minHeight: 6,
+            value: progress,
+            backgroundColor: context.colorScheme.primary.opacity15,
+          ),
+          const SizedBox(height: 8),
+        ],
         Text(
-          '$useShow / $totalShow · $expireShow',
+          total == 0
+              ? '$useShow / ∞ · $expireShow'
+              : '$useShow / $totalShow · $expireShow',
           style: context.textTheme.labelMedium?.toLight,
         ),
         const SizedBox(height: 4),


### PR DESCRIPTION
## Summary

Display used traffic and expiration time for subscriptions with unlimited traffic.

## Problem

`SubscriptionInfoView` currently returns an empty container when
`subscriptionInfo.total == 0`.

Some subscription providers use `total=0` to represent unlimited traffic.
In this case, FlClash hides the entire subscription information section,
even when valid used traffic and expiration information are available.

## Changes

- Keep the existing display unchanged for subscriptions with a finite traffic limit.
- Hide the progress bar when the total traffic is unlimited because no meaningful percentage can be calculated.
- Display unlimited subscriptions in the following format:

  `used traffic / ∞ · expiration time`

- Avoid division by zero when `total == 0`.
- No changes to subscription parsing, models, or localization resources.

## Expected behavior

### Finite traffic

`1.25 GB / 100 GB · 2026-09-26`

The progress bar remains visible.

### Unlimited traffic

`1.25 GB / ∞ · 2026-09-26`

The progress bar is not displayed.

## Testing

- [x] Ran `dart format lib/widgets/subscription_info_view.dart`
- [x] Ran `flutter analyze`
- [x] Verified a finite-traffic subscription still displays its progress bar
- [x] Verified an unlimited-traffic subscription displays used traffic and expiration time
- [x] Verified no division-by-zero or layout errors occur