### PR TITLE
Add Start/Stop app shortcuts

### DIFF
--- a/android/app/src/main/kotlin/com/follow/clash/plugins/AppPlugin.kt
+++ b/android/app/src/main/kotlin/com/follow/clash/plugins/AppPlugin.kt
@@ -199,9 +199,24 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
         val stopLabel = labels["stop"] ?: "Stop"
         val toggleLabel = labels["toggle"] ?: return
         val shortcuts = listOf(
-            buildShortcut("start", startLabel, QuickAction.START),
-            buildShortcut("stop", stopLabel, QuickAction.STOP),
-            buildShortcut("toggle", toggleLabel, QuickAction.TOGGLE),
+            buildShortcut(
+                id = "start",
+                label = startLabel,
+                action = QuickAction.START,
+                iconRes = R.drawable.ic_shortcut_start,
+            ),
+            buildShortcut(
+                id = "stop",
+                label = stopLabel,
+                action = QuickAction.STOP,
+                iconRes = R.drawable.ic_shortcut_stop,
+            ),
+            buildShortcut(
+                id = "toggle",
+                label = toggleLabel,
+                action = QuickAction.TOGGLE,
+                iconRes = R.mipmap.ic_launcher_round,
+            ),
         )
         ShortcutManagerCompat.setDynamicShortcuts(
             GlobalState.application, shortcuts
@@ -212,13 +227,14 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
         id: String,
         label: String,
         action: QuickAction,
+        iconRes: Int,
     ): ShortcutInfoCompat {
         return ShortcutInfoCompat.Builder(GlobalState.application, id)
             .setShortLabel(label)
             .setIcon(
                 IconCompat.createWithResource(
                     GlobalState.application,
-                    R.mipmap.ic_launcher_round,
+                    iconRes,
                 )
             )
             .setIntent(action.quickIntent)

--- a/android/app/src/main/kotlin/com/follow/clash/plugins/AppPlugin.kt
+++ b/android/app/src/main/kotlin/com/follow/clash/plugins/AppPlugin.kt
@@ -134,7 +134,11 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
             }
 
             "initShortcuts" -> {
-                initShortcuts(call.arguments as String)
+                val labels = call.arguments
+                if (labels is Map<*, *>) {
+                    @Suppress("UNCHECKED_CAST")
+                    initShortcuts(labels as Map<String, String>)
+                }
                 result.success(true)
             }
 
@@ -190,21 +194,35 @@ class AppPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityAware 
         }
     }
 
-    private fun initShortcuts(label: String) {
-        val shortcut = with(ShortcutInfoCompat.Builder(GlobalState.application, "toggle")) {
-            setShortLabel(label)
-            setIcon(
+    private fun initShortcuts(labels: Map<String, String>) {
+        val startLabel = labels["start"] ?: "Start"
+        val stopLabel = labels["stop"] ?: "Stop"
+        val toggleLabel = labels["toggle"] ?: return
+        val shortcuts = listOf(
+            buildShortcut("start", startLabel, QuickAction.START),
+            buildShortcut("stop", stopLabel, QuickAction.STOP),
+            buildShortcut("toggle", toggleLabel, QuickAction.TOGGLE),
+        )
+        ShortcutManagerCompat.setDynamicShortcuts(
+            GlobalState.application, shortcuts
+        )
+    }
+
+    private fun buildShortcut(
+        id: String,
+        label: String,
+        action: QuickAction,
+    ): ShortcutInfoCompat {
+        return ShortcutInfoCompat.Builder(GlobalState.application, id)
+            .setShortLabel(label)
+            .setIcon(
                 IconCompat.createWithResource(
                     GlobalState.application,
                     R.mipmap.ic_launcher_round,
                 )
             )
-            setIntent(QuickAction.TOGGLE.quickIntent)
-            build()
-        }
-        ShortcutManagerCompat.setDynamicShortcuts(
-            GlobalState.application, listOf(shortcut)
-        )
+            .setIntent(action.quickIntent)
+            .build()
     }
 
     private fun tip(message: String?) {

--- a/android/app/src/main/res/drawable/ic_shortcut_start.xml
+++ b/android/app/src/main/res/drawable/ic_shortcut_start.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <!-- Background matches the toggle/app adaptive icon (ic_launcher_background)
+         so Start/Stop shortcuts share the same backdrop as the toggle shortcut. -->
+    <path
+        android:pathData="M0,0 L48,0 L48,48 L0,48 Z"
+        android:fillColor="#FAFAFA"/>
+    <!-- Brand-blue play triangle glyph, centered like the adaptive-icon logomark -->
+    <path
+        android:pathData="M18.5,14 L18.5,34 L36,24 Z"
+        android:fillColor="#6666FB"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_shortcut_stop.xml
+++ b/android/app/src/main/res/drawable/ic_shortcut_stop.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <!-- Background matches the toggle/app adaptive icon (ic_launcher_background)
+         so Start/Stop shortcuts share the same backdrop as the toggle shortcut. -->
+    <path
+        android:pathData="M0,0 L48,0 L48,48 L0,48 Z"
+        android:fillColor="#FAFAFA"/>
+    <!-- Deep-blue stop square glyph, centered like the adaptive-icon logomark -->
+    <path
+        android:pathData="M15,15 L33,15 L33,33 L15,33 Z"
+        android:fillColor="#336AB6"/>
+</vector>

--- a/lib/plugins/app.dart
+++ b/lib/plugins/app.dart
@@ -78,7 +78,11 @@ class App {
   Future<bool?> initShortcuts() async {
     return methodChannel.invokeMethod<bool>(
       'initShortcuts',
-      currentAppLocalizations.toggle,
+      {
+        'start': currentAppLocalizations.start,
+        'stop': currentAppLocalizations.stop,
+        'toggle': currentAppLocalizations.toggle,
+      },
     );
   }
 


### PR DESCRIPTION
1.  The Start/Stop shortcuts reuse the existing START/STOP intents.
2.  Icons are consistent with app style.

<img width="40" height="40" alt="ic_shortcut_start" src="https://github.com/user-attachments/assets/7cbac814-50e7-4893-962c-6427e5faaba6" />
<img width="40" height="40" alt="ic_shortcut_stop" src="https://github.com/user-attachments/assets/931342ec-f8e2-465d-9f0e-f259f594a66b" />
