### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ brew install --cask flclash
 The easiest way to support developers is to click on the star (⭐) at the top of the page.
 
 <p style="text-align: center;">
-    <a href="https://api.star-history.com/svg?repos=chen08209/FlClash&Date">
-        <img alt="start" width=50% src="https://api.star-history.com/svg?repos=chen08209/FlClash&Date"/>
+    <a href="https://star-history.dera.page/#chen08209/FlClash&type=date">
+        <img alt="start" width=50% src="https://star-history.dera.page/svg?repos=chen08209/FlClash&Date"/>
     </a>
 </p>

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -133,7 +133,7 @@ brew install --cask flclash
 支持开发者的最简单方式是点击页面顶部的星标（⭐）。
 
 <p style="text-align: center;">
-    <a href="https://api.star-history.com/svg?repos=chen08209/FlClash&Date">
-        <img alt="start" width=50% src="https://api.star-history.com/svg?repos=chen08209/FlClash&Date"/>
+    <a href="https://star-history.dera.page/#chen08209/FlClash&type=date">
+        <img alt="start" width=50% src="https://star-history.dera.page/svg?repos=chen08209/FlClash&Date"/>
     </a>
 </p>


### PR DESCRIPTION
The star history chart in the README is currently broken because the old data source relies on the GitHub stargazer API, which is now restricted. This updates the chart links to a working source that requires no API token, so the chart renders correctly again for both the English and Chinese READMEs.