### PR TITLE
Resolve portable mode detection and handling

### DIFF
--- a/lib/common/path.dart
+++ b/lib/common/path.dart
@@ -2,33 +2,174 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:fl_clash/common/common.dart';
+import 'package:fl_clash/enum/enum.dart';
+import 'package:flutter/foundation.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 
 class AppPath {
   static AppPath? _instance;
+
+  @visibleForTesting
+  static String? appDirPathOverride;
+
+  @visibleForTesting
+  static Directory? legacyDataDirOverride;
+
   Completer<Directory> dataDir = Completer();
   late final Future<Directory?> _downloadDir = getDownloadsDirectory();
   Completer<Directory> tempDir = Completer();
   Completer<Directory> cacheDir = Completer();
   late String appDirPath;
+  bool isPortable = false;
+
+  @visibleForTesting
+  static void resetInstanceForTest({String? appDirPath, Directory? legacyDir}) {
+    _instance = null;
+    appDirPathOverride = appDirPath;
+    legacyDataDirOverride = legacyDir;
+  }
 
   AppPath._internal() {
-    appDirPath = join(dirname(Platform.resolvedExecutable));
-    getApplicationSupportDirectory().then((value) {
-      dataDir.complete(value);
-    });
-    getTemporaryDirectory().then((value) {
-      tempDir.complete(value);
-    });
-    getApplicationCacheDirectory().then((value) {
-      cacheDir.complete(value);
-    });
+    appDirPath = appDirPathOverride ?? join(dirname(Platform.resolvedExecutable));
+    _initDataDir();
+    _initTempDir();
+    _initCacheDir();
   }
 
   factory AppPath() {
     _instance ??= AppPath._internal();
     return _instance!;
+  }
+
+  Future<void> _initDataDir() async {
+    if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
+      final portableConfigDir = Directory(join(appDirPath, 'config'));
+      if (await portableConfigDir.exists()) {
+        isPortable = true;
+        await _migrateLegacyData(portableConfigDir);
+        dataDir.complete(portableConfigDir);
+        return;
+      }
+    }
+    final dir = await getApplicationSupportDirectory();
+    dataDir.complete(dir);
+  }
+
+  Future<void> _initCacheDir() async {
+    await dataDir.future;
+    if (isPortable) {
+      cacheDir.complete(Directory(join(await homeDirPath, '.cache')));
+      return;
+    }
+    final dir = await getApplicationCacheDirectory();
+    cacheDir.complete(dir);
+  }
+
+  Future<void> _initTempDir() async {
+    await dataDir.future;
+    if (isPortable) {
+      final portableTmpDir = Directory(join(await homeDirPath, 'tmp'));
+      if (await portableTmpDir.exists()) {
+        tempDir.complete(portableTmpDir);
+        return;
+      }
+    }
+    final dir = await getTemporaryDirectory();
+    tempDir.complete(dir);
+  }
+
+  Future<void> _migrateLegacyData(Directory portableConfigDir) async {
+    final legacyDir = _legacyDataDir();
+    if (legacyDir == null || legacyDir.path == portableConfigDir.path) return;
+    if (!await legacyDir.exists()) return;
+    await _copyMissingFile('shared_preferences.json', legacyDir, portableConfigDir);
+    await _copyMissingFile('database.sqlite', legacyDir, portableConfigDir);
+    await _copyMissingFile('config.yaml', legacyDir, portableConfigDir);
+    await _copyMissingFile('shared.json', legacyDir, portableConfigDir);
+    await _copyMissingDir('profiles', legacyDir, portableConfigDir);
+    await _copyMissingDir('scripts', legacyDir, portableConfigDir);
+  }
+
+  Directory? _legacyDataDir() {
+    if (legacyDataDirOverride != null) {
+      return legacyDataDirOverride;
+    }
+    if (Platform.isWindows) {
+      final appData = Platform.environment['APPDATA'];
+      if (appData == null || appData.isEmpty) return null;
+      return Directory(join(appData, 'com.follow', 'clash'));
+    }
+    if (Platform.isMacOS) {
+      final home = Platform.environment['HOME'];
+      if (home == null || home.isEmpty) return null;
+      return Directory(
+        join(home, 'Library', 'Application Support', 'com.follow.clash'),
+      );
+    }
+    if (Platform.isLinux) {
+      final dataHome = Platform.environment['XDG_DATA_HOME'];
+      if (dataHome != null && dataHome.isNotEmpty) {
+        return Directory(join(dataHome, 'com.follow.clash'));
+      }
+      final home = Platform.environment['HOME'];
+      if (home == null || home.isEmpty) return null;
+      return Directory(join(home, '.local', 'share', 'com.follow.clash'));
+    }
+    return null;
+  }
+
+  Future<void> _copyMissingFile(
+    String name,
+    Directory from,
+    Directory to,
+  ) async {
+    try {
+      final source = File(join(from.path, name));
+      if (!await source.exists()) return;
+      final target = File(join(to.path, name));
+      if (await target.exists()) return;
+      await target.create(recursive: true);
+      await source.copy(target.path);
+    } catch (e) {
+      commonPrint.log(
+        'Failed to migrate legacy file $name: $e',
+        logLevel: LogLevel.warning,
+      );
+    }
+  }
+
+  Future<void> _copyMissingDir(
+    String name,
+    Directory from,
+    Directory to,
+  ) async {
+    try {
+      final source = Directory(join(from.path, name));
+      if (!await source.exists()) return;
+      final target = Directory(join(to.path, name));
+      if (await target.exists()) return;
+      await target.create(recursive: true);
+      await for (final entity in source.list(
+        recursive: true,
+        followLinks: false,
+      )) {
+        final relativePath = relative(entity.path, from: source.path);
+        final destinationPath = join(target.path, relativePath);
+        if (entity is Directory) {
+          await Directory(destinationPath).create(recursive: true);
+        } else if (entity is File) {
+          final destination = File(destinationPath);
+          await destination.parent.create(recursive: true);
+          await entity.copy(destinationPath);
+        }
+      }
+    } catch (e) {
+      commonPrint.log(
+        'Failed to migrate legacy directory $name: $e',
+        logLevel: LogLevel.warning,
+      );
+    }
   }
 
   String get executableExtension {

--- a/lib/common/path.dart
+++ b/lib/common/path.dart
@@ -43,7 +43,7 @@ class AppPath {
   }
 
   Future<void> _initDataDir() async {
-    if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
+    if (system.isDesktop) {
       final portableConfigDir = Directory(join(appDirPath, 'config'));
       if (await portableConfigDir.exists()) {
         isPortable = true;

--- a/lib/common/preferences.dart
+++ b/lib/common/preferences.dart
@@ -1,22 +1,143 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
+import 'package:fl_clash/enum/enum.dart';
 import 'package:fl_clash/models/models.dart';
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'constant.dart';
+import 'file.dart';
+import 'path.dart';
+import 'print.dart';
+
+const _legacyKeyPrefix = 'flutter.';
+
+abstract class _PreferencesStore {
+  Future<Map<String, Object?>?> load();
+  Future<bool> save(Map<String, Object?> data);
+}
+
+class _FileStore implements _PreferencesStore {
+  final String? pathOverride;
+
+  _FileStore({this.pathOverride});
+
+  Future<String> _resolvePath() async =>
+      pathOverride ?? await appPath.sharedPreferencesPath;
+
+  @override
+  Future<Map<String, Object?>?> load() async {
+    try {
+      final file = File(await _resolvePath());
+      final Map<String, Object?> data = {};
+      if (await file.exists()) {
+        final content = await file.readAsString();
+        if (content.isNotEmpty) {
+          final decoded = jsonDecode(content);
+          if (decoded is! Map) {
+            throw const FormatException('Preferences file is not a JSON map');
+          }
+          for (final MapEntry(:key, :value) in decoded.entries) {
+            data[key.startsWith(_legacyKeyPrefix)
+                ? key.substring(_legacyKeyPrefix.length)
+                : key] = value;
+          }
+        }
+      }
+      return data;
+    } catch (e) {
+      commonPrint.log(
+        'Failed to load preferences: $e',
+        logLevel: LogLevel.warning,
+      );
+      return null;
+    }
+  }
+
+  @override
+  Future<bool> save(Map<String, Object?> data) async {
+    try {
+      final file = File(await _resolvePath());
+      await file.safeWriteAsString(jsonEncode(data));
+      return true;
+    } catch (e) {
+      commonPrint.log(
+        'Failed to save preferences: $e',
+        logLevel: LogLevel.warning,
+      );
+      return false;
+    }
+  }
+}
+
+class _SharedPreferencesStore implements _PreferencesStore {
+  @override
+  Future<Map<String, Object?>?> load() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final data = <String, Object?>{};
+      for (final key in prefs.getKeys()) {
+        data[key] = prefs.get(key);
+      }
+      return data;
+    } catch (e) {
+      commonPrint.log(
+        'Failed to load preferences: $e',
+        logLevel: LogLevel.warning,
+      );
+      return null;
+    }
+  }
+
+  @override
+  Future<bool> save(Map<String, Object?> data) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.clear();
+      final results = <Future<bool>>[];
+      data.forEach((key, value) {
+        results.add(_setSharedPreferencesValue(prefs, key, value));
+      });
+      return (await Future.wait(results)).every((result) => result);
+    } catch (e) {
+      commonPrint.log(
+        'Failed to save preferences: $e',
+        logLevel: LogLevel.warning,
+      );
+      return false;
+    }
+  }
+}
+
+Future<bool> _setSharedPreferencesValue(
+  SharedPreferences prefs,
+  String key,
+  Object? value,
+) {
+  return switch (value) {
+    int() => prefs.setInt(key, value),
+    String() => prefs.setString(key, value),
+    bool() => prefs.setBool(key, value),
+    double() => prefs.setDouble(key, value),
+    List<String>() => prefs.setStringList(key, value),
+    _ => Future.value(false),
+  };
+}
 
 class Preferences {
   static Preferences? _instance;
-  Completer<SharedPreferences?> sharedPreferencesCompleter = Completer();
+  final _PreferencesStore _store;
+  final Completer<Map<String, Object?>?> _preferencesCompleter = Completer();
 
-  Future<bool> get isInit async =>
-      await sharedPreferencesCompleter.future != null;
-
-  Preferences._internal() {
-    SharedPreferences.getInstance()
-        .then((value) => sharedPreferencesCompleter.complete(value))
-        .onError((_, _) => sharedPreferencesCompleter.complete(null));
+  Preferences._internal({String? pathOverride})
+    : _store = pathOverride != null
+          ? _FileStore(pathOverride: pathOverride)
+          : Platform.isWindows || Platform.isMacOS || Platform.isLinux
+          ? _FileStore()
+          : _SharedPreferencesStore() {
+    _init();
   }
 
   factory Preferences() {
@@ -24,27 +145,60 @@ class Preferences {
     return _instance!;
   }
 
+  @visibleForTesting
+  static Preferences createForTest({String? path}) {
+    return Preferences._internal(pathOverride: path);
+  }
+
+  Future<Map<String, Object?>?> get _preferences async =>
+      _preferencesCompleter.future;
+
+  Future<bool> get isInit async => await _preferences != null;
+
+  Future<void> _init() async {
+    try {
+      final data = await _store.load();
+      _preferencesCompleter.complete(data);
+    } catch (e) {
+      commonPrint.log(
+        'Failed to load preferences: $e',
+        logLevel: LogLevel.warning,
+      );
+      _preferencesCompleter.complete(null);
+    }
+  }
+
+  Future<bool> _save() async {
+    final data = await _preferences;
+    if (data == null) return false;
+    return _store.save(data);
+  }
+
   Future<int> getVersion() async {
-    final preferences = await sharedPreferencesCompleter.future;
-    return preferences?.getInt('version') ?? 0;
+    final preferences = await _preferences;
+    return preferences?['version'] as int? ?? 0;
   }
 
   Future<void> setVersion(int version) async {
-    final preferences = await sharedPreferencesCompleter.future;
-    await preferences?.setInt('version', version);
+    final preferences = await _preferences;
+    if (preferences == null) return;
+    preferences['version'] = version;
+    await _save();
   }
 
   Future<void> saveShareState(SharedState shareState) async {
-    final preferences = await sharedPreferencesCompleter.future;
-    await preferences?.setString('sharedState', json.encode(shareState));
+    final preferences = await _preferences;
+    if (preferences == null) return;
+    preferences['sharedState'] = jsonEncode(shareState);
+    await _save();
   }
 
   Future<Map<String, Object?>?> getConfigMap() async {
     try {
-      final preferences = await sharedPreferencesCompleter.future;
-      final configString = preferences?.getString(configKey);
+      final preferences = await _preferences;
+      final configString = preferences?[configKey] as String?;
       if (configString == null) return null;
-      final Map<String, Object?>? configMap = json.decode(configString);
+      final Map<String, Object?>? configMap = jsonDecode(configString);
       return configMap;
     } catch (_) {
       return null;
@@ -53,10 +207,10 @@ class Preferences {
 
   Future<Map<String, Object?>?> getClashConfigMap() async {
     try {
-      final preferences = await sharedPreferencesCompleter.future;
-      final clashConfigString = preferences?.getString(clashConfigKey);
+      final preferences = await _preferences;
+      final clashConfigString = preferences?[clashConfigKey] as String?;
       if (clashConfigString == null) return null;
-      return json.decode(clashConfigString);
+      return jsonDecode(clashConfigString) as Map<String, Object?>;
     } catch (_) {
       return null;
     }
@@ -64,9 +218,10 @@ class Preferences {
 
   Future<void> clearClashConfig() async {
     try {
-      final preferences = await sharedPreferencesCompleter.future;
-      await preferences?.remove(clashConfigKey);
-      return;
+      final preferences = await _preferences;
+      if (preferences == null) return;
+      preferences.remove(clashConfigKey);
+      await _save();
     } catch (_) {
       return;
     }
@@ -81,13 +236,17 @@ class Preferences {
   }
 
   Future<bool> saveConfig(Config config) async {
-    final preferences = await sharedPreferencesCompleter.future;
-    return preferences?.setString(configKey, json.encode(config)) ?? false;
+    final preferences = await _preferences;
+    if (preferences == null) return false;
+    preferences[configKey] = jsonEncode(config);
+    return _save();
   }
 
   Future<void> clearPreferences() async {
-    final sharedPreferencesIns = await sharedPreferencesCompleter.future;
-    await sharedPreferencesIns?.clear();
+    final preferences = await _preferences;
+    if (preferences == null) return;
+    preferences.clear();
+    await _save();
   }
 }
 

--- a/lib/common/preferences.dart
+++ b/lib/common/preferences.dart
@@ -11,6 +11,7 @@ import 'constant.dart';
 import 'file.dart';
 import 'path.dart';
 import 'print.dart';
+import 'system.dart';
 
 const _legacyKeyPrefix = 'flutter.';
 
@@ -134,7 +135,7 @@ class Preferences {
   Preferences._internal({String? pathOverride})
     : _store = pathOverride != null
           ? _FileStore(pathOverride: pathOverride)
-          : Platform.isWindows || Platform.isMacOS || Platform.isLinux
+          : system.isDesktop
           ? _FileStore()
           : _SharedPreferencesStore() {
     _init();

--- a/setup.dart
+++ b/setup.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:archive/archive.dart';
 import 'package:args/args.dart';
 import 'package:path/path.dart' as p;
 
@@ -199,7 +200,39 @@ Future<int> _package(
     stderr.write(utf8.decode(data));
   });
   final exitCode = await process.exitCode;
+  if (exitCode == 0 && platform == 'windows') {
+    await _injectPortableConfigDir(rootDir);
+  }
   return exitCode;
+}
+
+Future<void> _injectPortableConfigDir(String rootDir) async {
+  final distDir = Directory(p.join(rootDir, 'dist'));
+  if (!await distDir.exists()) return;
+  await for (final entity in distDir.list(recursive: true)) {
+    if (entity is! File || !entity.path.toLowerCase().endsWith('.zip')) {
+      continue;
+    }
+    try {
+      await injectPortableConfigDirIntoZip(entity.path);
+      stdout.writeln('Injected config/ into ${entity.path}');
+    } catch (e) {
+      stderr.writeln('Failed to inject config/ into ${entity.path}: $e');
+    }
+  }
+}
+
+Future<void> injectPortableConfigDirIntoZip(String zipPath) async {
+  final bytes = await File(zipPath).readAsBytes();
+  final archive = ZipDecoder().decodeBytes(bytes);
+  if (archive.find('config/') != null) {
+    return;
+  }
+  archive.addFile(ArchiveFile.directory('config/'));
+  final encoded = ZipEncoder().encode(archive);
+  final tmp = File('$zipPath.tmp');
+  await tmp.writeAsBytes(encoded, flush: true);
+  await tmp.rename(zipPath);
 }
 
 String _detectArch() {

--- a/test/common/path_test.dart
+++ b/test/common/path_test.dart
@@ -1,0 +1,130 @@
+import 'dart:io';
+
+import 'package:fl_clash/common/path.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  final String root;
+
+  _FakePathProvider(this.root);
+
+  @override
+  Future<String?> getTemporaryPath() async => root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => root;
+
+  @override
+  Future<String?> getApplicationCachePath() async => root;
+}
+
+void main() {
+  late Directory tempDir;
+  late Directory appDir;
+  late Directory supportDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('path_test');
+    appDir = Directory('${tempDir.path}/app')..createSync(recursive: true);
+    supportDir = Directory('${tempDir.path}/support')
+      ..createSync(recursive: true);
+    PathProviderPlatform.instance = _FakePathProvider(supportDir.path);
+  });
+
+  tearDown(() {
+    try {
+      tempDir.deleteSync(recursive: true);
+    } catch (_) {}
+  });
+
+  group('AppPath portable detection', () {
+    test('detects portable mode when config/ exists next to the executable', () async {
+      Directory('${appDir.path}/config').createSync();
+      AppPath.resetInstanceForTest(appDirPath: appDir.path);
+      addTearDown(AppPath.resetInstanceForTest);
+
+      final path = AppPath();
+      await path.homeDirPath;
+
+      expect(path.isPortable, isTrue);
+      expect(await path.homeDirPath, p.join(appDir.path, 'config'));
+      expect(await path.databasePath, p.join(appDir.path, 'config', 'database.sqlite'));
+    });
+
+    test('falls back to the application support directory without config/', () async {
+      AppPath.resetInstanceForTest(appDirPath: appDir.path);
+      addTearDown(AppPath.resetInstanceForTest);
+
+      final path = AppPath();
+      await path.homeDirPath;
+
+      expect(path.isPortable, isFalse);
+      expect(await path.homeDirPath, supportDir.path);
+    });
+
+    test('redirects cache into the portable config dir', () async {
+      Directory('${appDir.path}/config').createSync();
+      AppPath.resetInstanceForTest(appDirPath: appDir.path);
+      addTearDown(AppPath.resetInstanceForTest);
+
+      final path = AppPath();
+
+      expect((await path.cacheDir.future).path, p.join(appDir.path, 'config', '.cache'));
+    });
+
+    test('migrates legacy system data into a fresh portable config dir', () async {
+      final legacyDir = Directory('${tempDir.path}/legacy')..createSync();
+      final configDir = Directory('${appDir.path}/config')..createSync();
+      File('${legacyDir.path}/shared_preferences.json').writeAsStringSync(
+        '{"version":1}',
+      );
+      File('${legacyDir.path}/database.sqlite').writeAsBytesSync([1, 2, 3]);
+      Directory('${legacyDir.path}/profiles').createSync();
+      File('${legacyDir.path}/profiles/default.yaml').writeAsStringSync(
+        'mixed-port: 7890',
+      );
+
+      AppPath.resetInstanceForTest(
+        appDirPath: appDir.path,
+        legacyDir: legacyDir,
+      );
+      addTearDown(AppPath.resetInstanceForTest);
+
+      final path = AppPath();
+      await path.homeDirPath;
+
+      expect(
+        File('${configDir.path}/shared_preferences.json').existsSync(),
+        isTrue,
+      );
+      expect(File('${configDir.path}/database.sqlite').existsSync(), isTrue);
+      expect(
+        File('${configDir.path}/profiles/default.yaml').existsSync(),
+        isTrue,
+      );
+    });
+
+    test('migration does not overwrite existing portable data', () async {
+      final legacyDir = Directory('${tempDir.path}/legacy')..createSync();
+      final configDir = Directory('${appDir.path}/config')..createSync();
+      File('${configDir.path}/database.sqlite').writeAsBytesSync([9, 9]);
+      File('${legacyDir.path}/database.sqlite').writeAsBytesSync([1, 2, 3]);
+
+      AppPath.resetInstanceForTest(
+        appDirPath: appDir.path,
+        legacyDir: legacyDir,
+      );
+      addTearDown(AppPath.resetInstanceForTest);
+
+      final path = AppPath();
+      await path.homeDirPath;
+
+      expect(
+        File('${configDir.path}/database.sqlite').readAsBytesSync(),
+        [9, 9],
+      );
+    });
+  });
+}

--- a/test/common/preferences_test.dart
+++ b/test/common/preferences_test.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:fl_clash/common/preferences.dart';
+import 'package:fl_clash/models/models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('preferences_test');
+  });
+
+  tearDown(() {
+    try {
+      tempDir.deleteSync(recursive: true);
+    } catch (_) {}
+  });
+
+  String storagePath() => '${tempDir.path}/shared_preferences.json';
+
+  group('Preferences', () {
+    test('round-trips version and config', () async {
+      final prefs = Preferences.createForTest(path: storagePath());
+
+      expect(await prefs.getVersion(), 0);
+      expect(await prefs.getConfig(), isNull);
+
+      await prefs.setVersion(1);
+      const config = Config(themeProps: defaultThemeProps);
+      expect(await prefs.saveConfig(config), isTrue);
+
+      final reloaded = Preferences.createForTest(path: storagePath());
+      expect(await reloaded.getVersion(), 1);
+      expect((await reloaded.getConfig())?.themeProps, defaultThemeProps);
+    });
+
+    test('strips the legacy flutter. prefix from migrated files', () async {
+      const config = Config(themeProps: defaultThemeProps);
+      await File(storagePath()).writeAsString(
+        jsonEncode({
+          'flutter.version': 2,
+          'flutter.config': jsonEncode(config),
+        }),
+      );
+
+      final prefs = Preferences.createForTest(path: storagePath());
+
+      expect(await prefs.getVersion(), 2);
+      expect(await prefs.getConfig(), isNotNull);
+    });
+
+    test('reports isInit false when the file is corrupt', () async {
+      await File(storagePath()).writeAsString('not json');
+
+      final prefs = Preferences.createForTest(path: storagePath());
+
+      expect(await prefs.isInit, isFalse);
+    });
+
+    test('handles a missing file as an empty store', () async {
+      final prefs = Preferences.createForTest(path: storagePath());
+
+      expect(await prefs.isInit, isTrue);
+      expect(await prefs.getVersion(), 0);
+    });
+
+    test('saves shared state and clears all values', () async {
+      final prefs = Preferences.createForTest(path: storagePath());
+
+      await prefs.setVersion(1);
+      await prefs.saveShareState(
+        const SharedState(
+          setupParams: null,
+          vpnOptions: null,
+          stopTip: '',
+          startTip: '',
+          currentProfileName: 'test',
+          stopText: '',
+          onlyStatisticsProxy: false,
+          crashlytics: false,
+        ),
+      );
+
+      final raw = jsonDecode(await File(storagePath()).readAsString())
+          as Map<String, dynamic>;
+      expect(raw, contains('sharedState'));
+
+      await prefs.clearPreferences();
+      final cleared = Preferences.createForTest(path: storagePath());
+      expect(await cleared.getVersion(), 0);
+    });
+  });
+}

--- a/test/setup_test.dart
+++ b/test/setup_test.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:archive/archive.dart';
 import 'package:test/test.dart';
 
 import '../setup.dart' as setup;
@@ -45,6 +48,50 @@ void main() {
         'dart-define-from-file=env.json',
         'split-per-abi',
       ]);
+    });
+  });
+
+  group('portable zip packaging', () {
+    test('injects an empty config/ entry into a windows zip', () async {
+      final tmp = Directory.systemTemp.createTempSync('setup_zip_test');
+      addTearDown(() {
+        try {
+          tmp.deleteSync(recursive: true);
+        } catch (_) {}
+      });
+      final zipPath = '${tmp.path}/FlClash-0.8.96-windows-amd64.zip';
+      final archive = Archive()
+        ..addFile(ArchiveFile.bytes('FlClash.exe', [1, 2, 3]));
+      await File(zipPath).writeAsBytes(ZipEncoder().encode(archive));
+
+      await setup.injectPortableConfigDirIntoZip(zipPath);
+
+      final decoded = ZipDecoder().decodeBytes(
+        await File(zipPath).readAsBytes(),
+      );
+      expect(decoded.find('config/'), isNotNull);
+      expect(decoded.find('FlClash.exe'), isNotNull);
+    });
+
+    test('does not add a duplicate config/ entry when one already exists', () async {
+      final tmp = Directory.systemTemp.createTempSync('setup_zip_test');
+      addTearDown(() {
+        try {
+          tmp.deleteSync(recursive: true);
+        } catch (_) {}
+      });
+      final zipPath = '${tmp.path}/FlClash-0.8.96-windows-amd64.zip';
+      final archive = Archive()
+        ..addFile(ArchiveFile.directory('config/'))
+        ..addFile(ArchiveFile.bytes('FlClash.exe', [1, 2, 3]));
+      await File(zipPath).writeAsBytes(ZipEncoder().encode(archive));
+
+      await setup.injectPortableConfigDirIntoZip(zipPath);
+
+      final decoded = ZipDecoder().decodeBytes(
+        await File(zipPath).readAsBytes(),
+      );
+      expect(decoded.where((f) => f.name == 'config/').length, 1);
     });
   });
 }


### PR DESCRIPTION
This PR provides the final solution for portable mode detection and handling inspired by [Visual Studio Code's portable design](https://code.visualstudio.com/docs/setup/portable).

### Features:
- Data lives next to the executable (`config/` beside FlClash.exe, like VS Code's `data/`)
- Presence of the folder activates portable mode (isPortable = true if `config/` exists, so portable mode can be activated/deactivated via creating/removing the `config/` folder)
- One-time migration from an existing install (`%APPDATA%/com.follow/clash` → portable `config/`) with improvement over VS Code: migration only copies missing files/dirs, never overwrites existing portable data.
- `tmp/` folder next to the app redirects the temp directory (same trick as VS Code)
- Keep the `config/` folder while upgrading

All features have been tested to work properly. **You can download the release from [here](https://github.com/Spr-Aachen/FlClash/releases/tag/v0.8.96%2B) to give it a try.**

---

Issues that can be resolved: #1882 #1228