### PR TITLE
fix: WebDAV restore crash - _Map<String,dynamic> is not a subtype of ResponseBody?

### DIFF
--- a/plugins/webdav_client_fork/lib/src/adapter/adapter_mobile.dart
+++ b/plugins/webdav_client_fork/lib/src/adapter/adapter_mobile.dart
@@ -1,0 +1,4 @@
+import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
+
+HttpClientAdapter getAdapter() => IOHttpClientAdapter();

--- a/plugins/webdav_client_fork/lib/src/adapter/adapter_stub.dart
+++ b/plugins/webdav_client_fork/lib/src/adapter/adapter_stub.dart
@@ -1,0 +1,4 @@
+import 'package:dio/dio.dart';
+
+HttpClientAdapter getAdapter() =>
+    throw UnsupportedError('Cannot implement adapter');

--- a/plugins/webdav_client_fork/lib/src/adapter/adapter_web.dart
+++ b/plugins/webdav_client_fork/lib/src/adapter/adapter_web.dart
@@ -1,0 +1,4 @@
+import 'package:dio/browser.dart';
+import 'package:dio/dio.dart';
+
+HttpClientAdapter getAdapter() => BrowserHttpClientAdapter();

--- a/plugins/webdav_client_fork/lib/src/auth.dart
+++ b/plugins/webdav_client_fork/lib/src/auth.dart
@@ -1,0 +1,181 @@
+import 'dart:convert';
+import 'utils.dart';
+
+/// Auth type
+enum AuthType {
+  NoAuth,
+  BasicAuth,
+  DigestAuth,
+}
+
+/// Auth -----------------------------------
+class Auth {
+  /// username
+  final String user;
+
+  /// password
+  final String pwd;
+
+  const Auth({
+    required String user,
+    required String pwd,
+  })  : this.user = user,
+        this.pwd = pwd;
+
+  /// Get auth type
+  AuthType get type => AuthType.NoAuth;
+
+  /// Get authorization data
+  String? authorize(String method, String path) => null;
+}
+
+/// BasicAuth ------------------------------------
+class BasicAuth extends Auth {
+  const BasicAuth({
+    required String user,
+    required String pwd,
+  }) : super(
+          user: user,
+          pwd: pwd,
+        );
+
+  @override
+  AuthType get type => AuthType.BasicAuth;
+
+  @override
+  String authorize(String method, String path) {
+    List<int> bytes = utf8.encode('${this.user}:${this.pwd}');
+    return 'Basic ${base64Encode(bytes)}';
+  }
+}
+
+// DigestAuth ----------------------------------
+class DigestAuth extends Auth {
+  DigestParts dParts;
+
+  DigestAuth({
+    required String user,
+    required String pwd,
+    required this.dParts,
+  }) : super(
+          user: user,
+          pwd: pwd,
+        );
+
+  String? get nonce => this.dParts.parts['nonce'];
+
+  String? get realm => this.dParts.parts['realm'];
+
+  String? get qop => this.dParts.parts['qop'];
+
+  String? get opaque => this.dParts.parts['opaque'];
+
+  String? get algorithm => this.dParts.parts['algorithm'];
+
+  String? get entityBody => this.dParts.parts['entityBody'];
+
+  @override
+  AuthType get type => AuthType.DigestAuth;
+
+  @override
+  String authorize(String method, String path) {
+    this.dParts.uri = Uri.encodeFull(path);
+    this.dParts.method = method;
+    // Uri.encodeComponent fix not ascii
+    return this._getDigestAuthorization();
+  }
+
+  String _getDigestAuthorization() {
+    int nonceCount = 1;
+    String cnonce = computeNonce();
+    String ha1 = _computeHA1(nonceCount, cnonce);
+    String ha2 = _computeHA2();
+    String response = _computeResponse(ha1, ha2, nonceCount, cnonce);
+    String authorization =
+        'Digest username="${this.user}", realm="${this.realm}", nonce="${this.nonce}", uri="${this.dParts.uri}", nc=$nonceCount, cnonce="$cnonce", response="$response"';
+
+    if (this.qop?.isNotEmpty == true) {
+      authorization += ', qop=${this.qop}';
+    }
+
+    if (this.opaque?.isNotEmpty == true) {
+      authorization += ', opaque=${this.opaque}';
+    }
+
+    return authorization;
+  }
+
+  //
+  String _computeHA1(int nonceCount, String cnonce) {
+    String? algorithm = this.algorithm;
+
+    if (algorithm == 'MD5' || algorithm?.isEmpty != false) {
+      return md5Hash('${this.user}:${this.realm}:${this.pwd}');
+    } else if (algorithm == 'MD5-sess') {
+      String md5Str = md5Hash('${this.user}:${this.realm}:${this.pwd}');
+      return md5Hash('$md5Str:$nonceCount:$cnonce');
+    }
+
+    return '';
+  }
+
+  //
+  String _computeHA2() {
+    String? qop = this.qop;
+
+    if (qop == 'auth' || qop?.isEmpty != false) {
+      return md5Hash('${this.dParts.method}:${this.dParts.uri}');
+    } else if (qop == 'auth-int' && this.entityBody?.isEmpty == false) {
+      return md5Hash(
+          '${this.dParts.method}:${this.dParts.uri}:${md5Hash(this.entityBody!)}');
+    }
+
+    return '';
+  }
+
+  //
+  String _computeResponse(
+      String ha1, String ha2, int nonceCount, String cnonce) {
+    String? qop = this.qop;
+
+    if (qop?.isEmpty != false) {
+      return md5Hash('$ha1:${this.nonce}:$ha2');
+    } else if (qop == 'auth' || qop == 'auth-int') {
+      return md5Hash('$ha1:${this.nonce}:$nonceCount:$cnonce:$qop:$ha2');
+    }
+
+    return '';
+  }
+}
+
+/// DigestParts
+class DigestParts {
+  String uri = '';
+  String method = '';
+
+  Map<String, String> parts = {
+    'nonce': '',
+    'realm': '',
+    'qop': '',
+    'opaque': '',
+    'algorithm': '',
+    'entityBody': '',
+  };
+
+  DigestParts(String? authHeader) {
+    if (authHeader != null) {
+      var keys = parts.keys;
+      var list = authHeader.split(',');
+      list.forEach((kv) {
+        keys.forEach((k) {
+          if (kv.contains(k)) {
+            var index = kv.indexOf('=');
+            if (kv.length - 1 > index) {
+              parts[k] = trim(kv.substring(index + 1), '"');
+            }
+          }
+        });
+      });
+    }
+  }
+}

--- a/plugins/webdav_client_fork/lib/src/client.dart
+++ b/plugins/webdav_client_fork/lib/src/client.dart
@@ -1,0 +1,228 @@
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'dart:io' as io;
+import 'auth.dart';
+import 'file.dart';
+import 'utils.dart';
+import 'webdav_dio.dart';
+import 'xml.dart';
+
+/// WebDav Client
+class Client {
+  /// WebDAV url
+  final String uri;
+
+  /// Wrapped http client
+  WdDio c;
+
+  /// Auth Mode (noAuth/basic/digest)
+  Auth auth;
+
+  /// debug
+  bool debug;
+
+  Client({
+    required this.uri,
+    required this.c,
+    required this.auth,
+    this.debug = false,
+  });
+
+  // methods--------------------------------
+
+  /// Set the public request headers
+  void setHeaders(Map<String, dynamic> headers) =>
+      this.c.options.headers = headers;
+
+  /// Set the connection server timeout time in milliseconds.
+  void setConnectTimeout(int timeout) =>
+      this.c.options.connectTimeout = Duration(milliseconds: timeout);
+
+  /// Set send data timeout time in milliseconds.
+  void setSendTimeout(int timeout) =>
+      this.c.options.sendTimeout = Duration(milliseconds: timeout);
+
+  /// Set transfer data time in milliseconds.
+  void setReceiveTimeout(int timeout) =>
+      this.c.options.receiveTimeout = Duration(milliseconds: timeout);
+
+  /// Test whether the service can connect
+  Future<void> ping([CancelToken? cancelToken]) async {
+    var resp = await c.wdOptions(this, '/', cancelToken: cancelToken);
+    if (resp.statusCode != 200) {
+      throw newResponseError(resp);
+    }
+  }
+
+  // Future<void> getQuota([CancelToken cancelToken]) async {
+  //   var resp = await c.wdQuota(this, quotaXmlStr, cancelToken: cancelToken);
+  //   print(resp);
+  // }
+
+  /// Read all files in a folder
+  Future<List<File>> readDir(String path, [CancelToken? cancelToken]) async {
+    path = fixSlashes(path);
+    var resp = await this
+        .c
+        .wdPropfind(this, path, true, fileXmlStr, cancelToken: cancelToken);
+
+    String str = resp.data;
+    return WebdavXml.toFiles(path, str);
+  }
+
+  /// Read a single files properties
+  Future<File> readProps(String path, [CancelToken? cancelToken]) async {
+    path = fixSlashes(path);
+    var resp = await this
+        .c
+        .wdPropfind(this, path, true, fileXmlStr, cancelToken: cancelToken);
+
+    String str = resp.data;
+    return WebdavXml.toFiles(path, str, skipSelf: false).first;
+  }
+
+  /// Create a folder
+  Future<void> mkdir(String path, [CancelToken? cancelToken]) async {
+    path = fixSlashes(path);
+    var resp = await this.c.wdMkcol(this, path, cancelToken: cancelToken);
+    var status = resp.statusCode;
+    if (status != 201 && status != 405) {
+      throw newResponseError(resp);
+    }
+  }
+
+  /// Recursively create folders
+  Future<void> mkdirAll(String path, [CancelToken? cancelToken]) async {
+    path = fixSlashes(path);
+    var resp = await this.c.wdMkcol(this, path, cancelToken: cancelToken);
+    var status = resp.statusCode;
+    if (status == 201 || status == 405) {
+      return;
+    } else if (status == 409) {
+      var paths = path.split('/');
+      var sub = '/';
+      for (var e in paths) {
+        if (e == '') {
+          continue;
+        }
+        sub += e + '/';
+        resp = await this.c.wdMkcol(this, sub, cancelToken: cancelToken);
+        status = resp.statusCode;
+        if (status != 201 && status != 405) {
+          throw newResponseError(resp);
+        }
+      }
+      return;
+    }
+    throw newResponseError(resp);
+  }
+
+  /// Remove a folder or file
+  /// If you remove the folder, some webdav services require a '/' at the end of the path.
+  Future<void> remove(String path, [CancelToken? cancelToken]) {
+    return removeAll(path, cancelToken);
+  }
+
+  /// Remove files
+  Future<void> removeAll(String path, [CancelToken? cancelToken]) async {
+    var resp = await this.c.wdDelete(this, path, cancelToken: cancelToken);
+    if (resp.statusCode == 200 ||
+        resp.statusCode == 204 ||
+        resp.statusCode == 404) {
+      return;
+    }
+    throw newResponseError(resp);
+  }
+
+  /// Rename a folder or file
+  /// If you rename the folder, some webdav services require a '/' at the end of the path.
+  Future<void> rename(String oldPath, String newPath, bool overwrite,
+      [CancelToken? cancelToken]) {
+    return this.c.wdCopyMove(this, oldPath, newPath, false, overwrite);
+  }
+
+  /// Copy a file / folder from A to B
+  /// If copied the folder (A > B), it will copy all the contents of folder A to folder B.
+  /// Some webdav services have been tested and found to delete the original contents of the B folder!!!
+  Future<void> copy(String oldPath, String newPath, bool overwrite,
+      [CancelToken? cancelToken]) {
+    return this.c.wdCopyMove(this, oldPath, newPath, true, overwrite);
+  }
+
+  /// Read the bytes of a file
+  /// It is best not to open debug mode, otherwise the byte data is too large and the output results in IDE cards, 😄
+  Future<List<int>> read(
+    String path, {
+    void Function(int count, int total)? onProgress,
+    CancelToken? cancelToken,
+  }) {
+    return this.c.wdReadWithBytes(
+          this,
+          path,
+          onProgress: onProgress,
+          cancelToken: cancelToken,
+        );
+  }
+
+  /// Read the bytes of a file with stream and write to a local file
+  Future<void> read2File(
+    String path,
+    String savePath, {
+    void Function(int count, int total)? onProgress,
+    CancelToken? cancelToken,
+  }) async {
+    await this.c.wdReadWithStream(
+          this,
+          path,
+          savePath,
+          onProgress: onProgress,
+          cancelToken: cancelToken,
+        );
+  }
+
+  /// Write the bytes to remote path
+  Future<void> write(
+    String path,
+    Uint8List data, {
+    void Function(int count, int total)? onProgress,
+    CancelToken? cancelToken,
+  }) {
+    return this.c.wdWriteWithBytes(
+          this,
+          path,
+          data,
+          onProgress: onProgress,
+          cancelToken: cancelToken,
+        );
+  }
+
+  /// Read local file stream and write to remote file
+  Future<void> writeFromFile(
+    String localFilePath,
+    String path, {
+    void Function(int count, int total)? onProgress,
+    CancelToken? cancelToken,
+  }) async {
+    var file = io.File(localFilePath);
+    return this.c.wdWriteWithStream(
+          this,
+          path,
+          file.openRead(),
+          file.lengthSync(),
+          onProgress: onProgress,
+          cancelToken: cancelToken,
+        );
+  }
+}
+
+/// create new client
+Client newClient(String uri,
+    {String user = '', String password = '', bool debug = false}) {
+  return Client(
+    uri: fixSlash(uri),
+    c: WdDio(debug: debug),
+    auth: Auth(user: user, pwd: password),
+    debug: debug,
+  );
+}

--- a/plugins/webdav_client_fork/lib/src/file.dart
+++ b/plugins/webdav_client_fork/lib/src/file.dart
@@ -1,0 +1,21 @@
+class File {
+  String? path;
+  bool? isDir;
+  String? name;
+  String? mimeType;
+  int? size;
+  String? eTag;
+  DateTime? cTime;
+  DateTime? mTime;
+
+  File({
+    this.path,
+    this.isDir,
+    this.name,
+    this.mimeType,
+    this.size,
+    this.eTag,
+    this.cTime,
+    this.mTime,
+  });
+}

--- a/plugins/webdav_client_fork/lib/src/md5.dart
+++ b/plugins/webdav_client_fork/lib/src/md5.dart
@@ -1,0 +1,222 @@
+// fork dart-sdk/lib/_http/crypto.dart
+
+// Constants.
+import 'dart:math';
+
+const _MASK_8 = 0xff;
+const _MASK_32 = 0xffffffff;
+const _BITS_PER_BYTE = 8;
+const _BYTES_PER_WORD = 4;
+
+abstract class _HashBase {
+  // Hasher state.
+  final int _chunkSizeInWords;
+  final bool _bigEndianWords;
+  int _lengthInBytes = 0;
+  List<int> _pendingData;
+  List<int> _currentChunk;
+  List<int> _h;
+  bool _digestCalled = false;
+
+  _HashBase(this._chunkSizeInWords, int digestSizeInWords, this._bigEndianWords)
+      : _pendingData = [],
+        _currentChunk = List.filled(_chunkSizeInWords, 0),
+        _h = List.filled(digestSizeInWords, 0);
+
+  // Update the hasher with more data.
+  add(List<int> data) {
+    if (_digestCalled) {
+      throw new StateError(
+          'Hash update method called after digest was retrieved');
+    }
+    _lengthInBytes += data.length;
+    _pendingData.addAll(data);
+    _iterate();
+  }
+
+  // Finish the hash computation and return the digest string.
+  List<int> close() {
+    if (_digestCalled) {
+      return _resultAsBytes();
+    }
+    _digestCalled = true;
+    _finalizeData();
+    _iterate();
+    assert(_pendingData.length == 0);
+    return _resultAsBytes();
+  }
+
+  // Returns the block size of the hash in bytes.
+  int get blockSize {
+    return _chunkSizeInWords * _BYTES_PER_WORD;
+  }
+
+  // Create a fresh instance of this Hash.
+  newInstance();
+
+  // One round of the hash computation.
+  _updateHash(List<int> m);
+
+  // Helper methods.
+  _add32(x, y) => (x + y) & _MASK_32;
+  _roundUp(val, n) => (val + n - 1) & -n;
+
+  // Rotate left limiting to unsigned 32-bit values.
+  int _rotl32(int val, int shift) {
+    var mod_shift = shift & 31;
+    return ((val << mod_shift) & _MASK_32) |
+        ((val & _MASK_32) >> (32 - mod_shift));
+  }
+
+  // Compute the final result as a list of bytes from the hash words.
+  List<int> _resultAsBytes() {
+    var result = <int>[];
+    for (var i = 0; i < _h.length; i++) {
+      result.addAll(_wordToBytes(_h[i]));
+    }
+    return result;
+  }
+
+  // Converts a list of bytes to a chunk of 32-bit words.
+  _bytesToChunk(List<int> data, int dataIndex) {
+    assert((data.length - dataIndex) >= (_chunkSizeInWords * _BYTES_PER_WORD));
+
+    for (var wordIndex = 0; wordIndex < _chunkSizeInWords; wordIndex++) {
+      var w3 = _bigEndianWords ? data[dataIndex] : data[dataIndex + 3];
+      var w2 = _bigEndianWords ? data[dataIndex + 1] : data[dataIndex + 2];
+      var w1 = _bigEndianWords ? data[dataIndex + 2] : data[dataIndex + 1];
+      var w0 = _bigEndianWords ? data[dataIndex + 3] : data[dataIndex];
+      dataIndex += 4;
+      var word = (w3 & 0xff) << 24;
+      word |= (w2 & _MASK_8) << 16;
+      word |= (w1 & _MASK_8) << 8;
+      word |= (w0 & _MASK_8);
+      _currentChunk[wordIndex] = word;
+    }
+  }
+
+  // Convert a 32-bit word to four bytes.
+  List<int> _wordToBytes(int word) {
+    List<int> bytes = new List.filled(_BYTES_PER_WORD, 0);
+    bytes[0] = (word >> (_bigEndianWords ? 24 : 0)) & _MASK_8;
+    bytes[1] = (word >> (_bigEndianWords ? 16 : 8)) & _MASK_8;
+    bytes[2] = (word >> (_bigEndianWords ? 8 : 16)) & _MASK_8;
+    bytes[3] = (word >> (_bigEndianWords ? 0 : 24)) & _MASK_8;
+    return bytes;
+  }
+
+  // Iterate through data updating the hash computation for each
+  // chunk.
+  _iterate() {
+    var len = _pendingData.length;
+    var chunkSizeInBytes = _chunkSizeInWords * _BYTES_PER_WORD;
+    if (len >= chunkSizeInBytes) {
+      var index = 0;
+      for (; (len - index) >= chunkSizeInBytes; index += chunkSizeInBytes) {
+        _bytesToChunk(_pendingData, index);
+        _updateHash(_currentChunk);
+      }
+      _pendingData = _pendingData.sublist(index, len);
+    }
+  }
+
+  // Finalize the data. Add a 1 bit to the end of the message. Expand with
+  // 0 bits and add the length of the message.
+  _finalizeData() {
+    _pendingData.add(0x80);
+    var contentsLength = _lengthInBytes + 9;
+    var chunkSizeInBytes = _chunkSizeInWords * _BYTES_PER_WORD;
+    var finalizedLength = _roundUp(contentsLength, chunkSizeInBytes);
+    var zeroPadding = finalizedLength - contentsLength;
+    for (var i = 0; i < zeroPadding; i++) {
+      _pendingData.add(0);
+    }
+    var lengthInBits = _lengthInBytes * _BITS_PER_BYTE;
+    assert(lengthInBits < pow(2, 32));
+    if (_bigEndianWords) {
+      _pendingData.addAll(_wordToBytes(0));
+      _pendingData.addAll(_wordToBytes(lengthInBits & _MASK_32));
+    } else {
+      _pendingData.addAll(_wordToBytes(lengthInBits & _MASK_32));
+      _pendingData.addAll(_wordToBytes(0));
+    }
+  }
+}
+
+// The MD5 hasher is used to compute an MD5 message digest.
+class MD5 extends _HashBase {
+  MD5() : super(16, 4, false) {
+    _h[0] = 0x67452301;
+    _h[1] = 0xefcdab89;
+    _h[2] = 0x98badcfe;
+    _h[3] = 0x10325476;
+  }
+
+  // Returns a new instance of this Hash.
+  MD5 newInstance() {
+    return new MD5();
+  }
+
+  static const _k = const [
+    0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a, //
+    0xa8304613, 0xfd469501, 0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be, //
+    0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821, 0xf61e2562, 0xc040b340, //
+    0x265e5a51, 0xe9b6c7aa, 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8, //
+    0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed, 0xa9e3e905, 0xfcefa3f8, //
+    0x676f02d9, 0x8d2a4c8a, 0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c, //
+    0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70, 0x289b7ec6, 0xeaa127fa, //
+    0xd4ef3085, 0x04881d05, 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665, //
+    0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039, 0x655b59c3, 0x8f0ccc92, //
+    0xffeff47d, 0x85845dd1, 0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1, //
+    0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391
+  ];
+
+  static const _r = const [
+    7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 5, 9, 14, //
+    20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 4, 11, 16, 23, 4, 11, //
+    16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 6, 10, 15, 21, 6, 10, 15, 21, 6, //
+    10, 15, 21, 6, 10, 15, 21
+  ];
+
+  // Compute one iteration of the MD5 algorithm with a chunk of
+  // 16 32-bit pieces.
+  void _updateHash(List<int> m) {
+    assert(m.length == 16);
+
+    var a = _h[0];
+    var b = _h[1];
+    var c = _h[2];
+    var d = _h[3];
+
+    var t0;
+    var t1;
+
+    for (var i = 0; i < 64; i++) {
+      if (i < 16) {
+        t0 = (b & c) | ((~b & _MASK_32) & d);
+        t1 = i;
+      } else if (i < 32) {
+        t0 = (d & b) | ((~d & _MASK_32) & c);
+        t1 = ((5 * i) + 1) % 16;
+      } else if (i < 48) {
+        t0 = b ^ c ^ d;
+        t1 = ((3 * i) + 5) % 16;
+      } else {
+        t0 = c ^ (b | (~d & _MASK_32));
+        t1 = (7 * i) % 16;
+      }
+
+      var temp = d;
+      d = c;
+      c = b;
+      b = _add32(
+          b, _rotl32(_add32(_add32(a, t0), _add32(_k[i], m[t1])), _r[i]));
+      a = temp;
+    }
+
+    _h[0] = _add32(a, _h[0]);
+    _h[1] = _add32(b, _h[1]);
+    _h[2] = _add32(c, _h[2]);
+    _h[3] = _add32(d, _h[3]);
+  }
+}

--- a/plugins/webdav_client_fork/lib/src/utils.dart
+++ b/plugins/webdav_client_fork/lib/src/utils.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+import 'dart:math' as math;
+
+import 'package:convert/convert.dart';
+import 'package:dio/dio.dart';
+import 'md5.dart';
+
+const months = {
+  'jan': '01',
+  'feb': '02',
+  'mar': '03',
+  'apr': '04',
+  'may': '05',
+  'jun': '06',
+  'jul': '07',
+  'aug': '08',
+  'sep': '09',
+  'oct': '10',
+  'nov': '11',
+  'dec': '12',
+};
+
+// md5
+String md5Hash(String data) {
+  MD5 hasher = new MD5()..add(Utf8Encoder().convert(data));
+  var bytes = hasher.close();
+  var result = new StringBuffer();
+  for (var part in bytes) {
+    result.write('${part < 16 ? '0' : ''}${part.toRadixString(16)}');
+  }
+  return result.toString();
+}
+
+DateTime? str2LocalTime(String? str) {
+  if (str == null) {
+    return null;
+  }
+  var s = str.toLowerCase();
+  if (!s.endsWith('gmt')) {
+    return null;
+  }
+  var list = s.split(' ');
+  if (list.length != 6) {
+    return null;
+  }
+  var month = months[list[2]];
+  if (month == null) {
+    return null;
+  }
+
+  return DateTime.parse(
+          '${list[3]}-$month-${list[1].padLeft(2, '0')}T${list[4]}Z')
+      .toLocal();
+}
+
+// create response error
+DioError newResponseError(Response resp) {
+  return DioError(
+      requestOptions: resp.requestOptions,
+      response: resp,
+      type: DioErrorType.badResponse,
+      error: resp.statusMessage);
+}
+
+// create xml error
+DioError newXmlError(dynamic err) {
+  return DioError(
+    requestOptions: RequestOptions(path: '/'),
+    type: DioErrorType.unknown,
+    error: err,
+  );
+}
+
+// 16进制字符串随机数
+String computeNonce() {
+  final rnd = math.Random.secure();
+  final values = List<int>.generate(16, (i) => rnd.nextInt(256));
+  return hex.encode(values).substring(0, 16);
+}
+
+String trim(String str, [String? chars]) {
+  RegExp pattern =
+      (chars != null) ? RegExp('^[$chars]+|[$chars]+\$') : RegExp(r'^\s+|\s+$');
+  return str.replaceAll(pattern, '');
+}
+
+String ltrim(String str, [String? chars]) {
+  var pattern = chars != null ? new RegExp('^[$chars]+') : new RegExp(r'^\s+');
+  return str.replaceAll(pattern, '');
+}
+
+String rtrim(String str, [String? chars]) {
+  var pattern = chars != null ? new RegExp('[$chars]+\$') : new RegExp(r'\s+$');
+  return str.replaceAll(pattern, '');
+}
+
+// 添加 '/' 后缀
+String fixSlash(String s) {
+  if (!s.endsWith('/')) {
+    return s + '/';
+  }
+  return s;
+}
+
+// 添加 '/' 前后缀
+String fixSlashes(String s) {
+  if (!s.startsWith('/')) {
+    s = '/${s}';
+  }
+  return fixSlash(s);
+}
+
+// 使用 '/' 连接path
+String join(String path0, String path1) {
+  return rtrim(path0, '/') + '/' + ltrim(path1, '/');
+}
+
+// 获取文件名
+String path2Name(String path) {
+  var str = rtrim(path, '/');
+  var index = str.lastIndexOf('/');
+  if (index > -1) {
+    str = str.substring(index + 1);
+  }
+  if (str == '') {
+    return '/';
+  }
+  return str;
+}

--- a/plugins/webdav_client_fork/lib/src/webdav_dio.dart
+++ b/plugins/webdav_client_fork/lib/src/webdav_dio.dart
@@ -1,0 +1,517 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'adapter/adapter_stub.dart'
+    if (dart.library.io) 'adapter/adapter_mobile.dart'
+    if (dart.library.js) 'adapter/adapter_web.dart';
+
+import 'package:dio/dio.dart';
+
+import 'auth.dart';
+import 'client.dart';
+import 'utils.dart';
+
+/// Wrapped http client
+class WdDio with DioMixin implements Dio {
+  // // Request config
+  // BaseOptions? baseOptions;
+
+  // Interceptors
+  final List<Interceptor>? interceptorList;
+
+  // debug
+  final bool debug;
+
+  WdDio({
+    BaseOptions? options,
+    this.interceptorList,
+    this.debug = false,
+  }) {
+    this.options = options ?? BaseOptions();
+    // 禁止重定向
+    this.options.followRedirects = false;
+
+    // 状态码错误视为成功
+    this.options.validateStatus = (status) => true;
+
+    httpClientAdapter = getAdapter();
+
+    // 拦截器
+    if (interceptorList != null) {
+      for (var item in interceptorList!) {
+        this.interceptors.add(item);
+      }
+    }
+
+    // debug
+    if (debug == true) {
+      this.interceptors.add(LogInterceptor(responseBody: true));
+    }
+  }
+
+  // methods-------------------------
+  Future<Response<T>> req<T>(
+    Client self,
+    String method,
+    String path, {
+    dynamic data,
+    Function(Options)? optionsHandler,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+    CancelToken? cancelToken,
+  }) async {
+    // options
+    Options options = Options(method: method);
+    if (options.headers == null) {
+      options.headers = {};
+    }
+
+    // 二次处理options
+    if (optionsHandler != null) {
+      optionsHandler(options);
+    }
+
+    // authorization
+    String? str = self.auth.authorize(method, path);
+    if (str != null) {
+      options.headers?['authorization'] = str;
+    }
+
+    var resp = await this.requestUri<T>(
+      Uri.parse(
+          '${path.startsWith(RegExp(r'(http|https)://')) ? path : join(self.uri, path)}'),
+      options: options,
+      data: data,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+      cancelToken: cancelToken,
+    );
+
+    if (resp.statusCode == 401) {
+      String? w3AHeader = resp.headers.value('www-authenticate');
+      String? lowerW3AHeader = w3AHeader?.toLowerCase();
+
+      // before is noAuth
+      if (self.auth.type == AuthType.NoAuth) {
+        // Digest
+        if (lowerW3AHeader?.contains('digest') == true) {
+          self.auth = DigestAuth(
+              user: self.auth.user,
+              pwd: self.auth.pwd,
+              dParts: DigestParts(w3AHeader));
+        }
+        // Basic
+        else if (lowerW3AHeader?.contains('basic') == true) {
+          self.auth = BasicAuth(user: self.auth.user, pwd: self.auth.pwd);
+        }
+        // error
+        else {
+          throw newResponseError(resp);
+        }
+      }
+      // before is digest and Nonce Lifetime is out
+      else if (self.auth.type == AuthType.DigestAuth &&
+          lowerW3AHeader?.contains('stale=true') == true) {
+        self.auth = DigestAuth(
+            user: self.auth.user,
+            pwd: self.auth.pwd,
+            dParts: DigestParts(w3AHeader));
+      } else {
+        throw newResponseError(resp);
+      }
+
+      // retry
+      return this.req<T>(
+        self,
+        method,
+        path,
+        data: data,
+        optionsHandler: optionsHandler,
+        onSendProgress: onSendProgress,
+        onReceiveProgress: onReceiveProgress,
+        cancelToken: cancelToken,
+      );
+    } else if (resp.statusCode == 302) {
+      // 文件位置被重定向到新路径
+      if (resp.headers.map.containsKey('location')) {
+        List<String>? list = resp.headers.map['location'];
+        if (list != null && list.isNotEmpty) {
+          String redirectPath = list[0];
+          // retry
+          return this.req<T>(
+            self,
+            method,
+            redirectPath,
+            data: data,
+            optionsHandler: optionsHandler,
+            onSendProgress: onSendProgress,
+            onReceiveProgress: onReceiveProgress,
+            cancelToken: cancelToken,
+          );
+        }
+      }
+    }
+
+    return resp;
+  }
+
+  // OPTIONS
+  Future<Response> wdOptions(Client self, String path,
+      {CancelToken? cancelToken}) {
+    return this.req(self, 'OPTIONS', path,
+        optionsHandler: (options) => options.headers?['depth'] = '0',
+        cancelToken: cancelToken);
+  }
+
+  // // quota
+  // Future<Response> wdQuota(Client self, String dataStr,
+  //     {CancelToken cancelToken}) {
+  //   return this.req(self, 'PROPFIND', '/', data: utf8.encode(dataStr),
+  //       optionsHandler: (options) {
+  //     options.headers['depth'] = '0';
+  //     options.headers['accept'] = 'text/plain';
+  //   }, cancelToken: cancelToken);
+  // }
+
+  // PROPFIND
+  Future<Response> wdPropfind(
+      Client self, String path, bool depth, String dataStr,
+      {CancelToken? cancelToken}) async {
+    var resp = await this.req(self, 'PROPFIND', path, data: dataStr,
+        optionsHandler: (options) {
+      options.headers?['depth'] = depth ? '1' : '0';
+      options.headers?['content-type'] = 'application/xml;charset=UTF-8';
+      options.headers?['accept'] = 'application/xml,text/xml';
+      options.headers?['accept-charset'] = 'utf-8';
+      options.headers?['accept-encoding'] = '';
+    }, cancelToken: cancelToken);
+
+    if (resp.statusCode != 207) {
+      throw newResponseError(resp);
+    }
+
+    return resp;
+  }
+
+  /// MKCOL
+  Future<Response> wdMkcol(Client self, String path,
+      {CancelToken? cancelToken}) {
+    return this.req(self, 'MKCOL', path, cancelToken: cancelToken);
+  }
+
+  /// DELETE
+  Future<Response> wdDelete(Client self, String path,
+      {CancelToken? cancelToken}) {
+    return this.req(self, 'DELETE', path, cancelToken: cancelToken);
+  }
+
+  /// COPY OR MOVE
+  Future<void> wdCopyMove(
+      Client self, String oldPath, String newPath, bool isCopy, bool overwrite,
+      {CancelToken? cancelToken}) async {
+    var method = isCopy == true ? 'COPY' : 'MOVE';
+    var resp = await this.req(self, method, oldPath, optionsHandler: (options) {
+      options.headers?['destination'] = Uri.encodeFull(join(self.uri, newPath));
+      options.headers?['overwrite'] = overwrite == true ? 'T' : 'F';
+    }, cancelToken: cancelToken);
+
+    var status = resp.statusCode;
+    // TODO 207
+    if (status == 201 || status == 204 || status == 207) {
+      return;
+    } else if (status == 409) {
+      await this._createParent(self, newPath, cancelToken: cancelToken);
+      return this.wdCopyMove(self, oldPath, newPath, isCopy, overwrite,
+          cancelToken: cancelToken);
+    } else {
+      throw newResponseError(resp);
+    }
+  }
+
+  /// create parent folder
+  Future<void>? _createParent(Client self, String path,
+      {CancelToken? cancelToken}) {
+    var parentPath = path.substring(0, path.lastIndexOf('/') + 1);
+
+    if (parentPath == '' || parentPath == '/') {
+      return null;
+    }
+    return self.mkdirAll(parentPath, cancelToken);
+  }
+
+  /// read a file with bytes
+  Future<List<int>> wdReadWithBytes(
+    Client self,
+    String path, {
+    void Function(int count, int total)? onProgress,
+    CancelToken? cancelToken,
+  }) async {
+    // fix auth error
+    var pResp = await this.wdOptions(self, path, cancelToken: cancelToken);
+    if (pResp.statusCode != 200) {
+      throw newResponseError(pResp);
+    }
+
+    var resp = await this.req(
+      self,
+      'GET',
+      path,
+      optionsHandler: (options) => options.responseType = ResponseType.bytes,
+      onReceiveProgress: onProgress,
+      cancelToken: cancelToken,
+    );
+    if (resp.statusCode != 200) {
+      if (resp.statusCode != null) {
+        if (resp.statusCode! >= 300 && resp.statusCode! < 400) {
+          return (await this.req(
+            self,
+            'GET',
+            resp.headers["location"]!.first,
+            optionsHandler: (options) =>
+                options.responseType = ResponseType.bytes,
+            onReceiveProgress: onProgress,
+            cancelToken: cancelToken,
+          ))
+              .data;
+        }
+      }
+      throw newResponseError(resp);
+    }
+    return resp.data;
+  }
+
+  /// read a file with stream
+  Future<void> wdReadWithStream(
+    Client self,
+    String path,
+    String savePath, {
+    void Function(int count, int total)? onProgress,
+    CancelToken? cancelToken,
+  }) async {
+    // fix auth error
+    var pResp = await this.wdOptions(self, path, cancelToken: cancelToken);
+    if (pResp.statusCode != 200) {
+      throw newResponseError(pResp);
+    }
+
+    Response<ResponseBody> resp;
+
+    // Reference Dio download
+    // request
+    try {
+      resp = await this.req<ResponseBody>(
+        self,
+        'GET',
+        path,
+        optionsHandler: (options) => options.responseType = ResponseType.stream,
+        // onReceiveProgress: onProgress,
+        cancelToken: cancelToken,
+      );
+    } on DioError catch (e) {
+      if (e.type == DioErrorType.badResponse) {
+        if (e.response!.requestOptions.receiveDataWhenStatusError == true) {
+          var res = await transformer.transformResponse(
+            e.response!.requestOptions..responseType = ResponseType.json,
+            e.response!.data as ResponseBody,
+          );
+          e.response!.data = res;
+        } else {
+          e.response!.data = null;
+        }
+      }
+      rethrow;
+    }
+    if (resp.statusCode != 200) {
+      throw newResponseError(resp);
+    }
+
+    resp.headers = Headers.fromMap(resp.data!.headers);
+
+    //If directory (or file) doesn't exist yet, the entire method fails
+    File file = File(savePath);
+    file.createSync(recursive: true);
+
+    var raf = file.openSync(mode: FileMode.write);
+
+    //Create a Completer to notify the success/error state.
+    var completer = Completer<Response>();
+    var future = completer.future;
+    var received = 0;
+
+    // Stream<Uint8List>
+    var stream = resp.data!.stream;
+    var compressed = false;
+    var total = 0;
+    var contentEncoding = resp.headers.value(Headers.contentEncodingHeader);
+    if (contentEncoding != null) {
+      compressed = ['gzip', 'deflate', 'compress'].contains(contentEncoding);
+    }
+    if (compressed) {
+      total = -1;
+    } else {
+      total =
+          int.parse(resp.headers.value(Headers.contentLengthHeader) ?? '-1');
+    }
+
+    late StreamSubscription subscription;
+    Future? asyncWrite;
+    var closed = false;
+    Future _closeAndDelete() async {
+      if (!closed) {
+        closed = true;
+        await asyncWrite;
+        await raf.close();
+        await file.delete();
+      }
+    }
+
+    subscription = stream.listen(
+      (data) {
+        subscription.pause();
+        // Write file asynchronously
+        asyncWrite = raf.writeFrom(data).then((_raf) {
+          // Notify progress
+          received += data.length;
+
+          onProgress?.call(received, total);
+
+          raf = _raf;
+          if (cancelToken == null || !cancelToken.isCancelled) {
+            subscription.resume();
+          }
+        }).catchError((err) async {
+          try {
+            await subscription.cancel();
+          } finally {
+            completer.completeError(DioError(
+              requestOptions: resp.requestOptions,
+              error: err,
+            ));
+          }
+        });
+      },
+      onDone: () async {
+        try {
+          await asyncWrite;
+          closed = true;
+          await raf.close();
+          completer.complete(resp);
+        } catch (err) {
+          completer.completeError(DioError(
+            requestOptions: resp.requestOptions,
+            error: err,
+          ));
+        }
+      },
+      onError: (e) async {
+        try {
+          await _closeAndDelete();
+        } finally {
+          completer.completeError(DioError(
+            requestOptions: resp.requestOptions,
+            error: e,
+          ));
+        }
+      },
+      cancelOnError: true,
+    );
+
+    // ignore: unawaited_futures
+    cancelToken?.whenCancel.then((_) async {
+      await subscription.cancel();
+      await _closeAndDelete();
+    });
+
+    if (resp.requestOptions.receiveTimeout != null &&
+        resp.requestOptions.receiveTimeout!
+                .compareTo(Duration(milliseconds: 0)) >
+            0) {
+      future = future
+          .timeout(resp.requestOptions.receiveTimeout!)
+          .catchError((Object err) async {
+        await subscription.cancel();
+        await _closeAndDelete();
+        if (err is TimeoutException) {
+          throw DioError(
+            requestOptions: resp.requestOptions,
+            error:
+                'Receiving data timeout[${resp.requestOptions.receiveTimeout}ms]',
+            type: DioErrorType.receiveTimeout,
+          );
+        } else {
+          throw err;
+        }
+      });
+    }
+    await DioMixin.listenCancelForAsyncTask(cancelToken, future);
+  }
+
+  /// write a file with bytes
+  Future<void> wdWriteWithBytes(
+    Client self,
+    String path,
+    Uint8List data, {
+    void Function(int count, int total)? onProgress,
+    CancelToken? cancelToken,
+  }) async {
+    // fix auth error
+    var pResp = await this.wdOptions(self, path, cancelToken: cancelToken);
+    if (pResp.statusCode != 200) {
+      throw newResponseError(pResp);
+    }
+
+    // mkdir
+    await this._createParent(self, path, cancelToken: cancelToken);
+
+    var resp = await this.req(
+      self,
+      'PUT',
+      path,
+      data: Stream.fromIterable(data.map((e) => [e])),
+      optionsHandler: (options) =>
+          options.headers?['content-length'] = data.length,
+      onSendProgress: onProgress,
+      cancelToken: cancelToken,
+    );
+    var status = resp.statusCode;
+    if (status == 200 || status == 201 || status == 204) {
+      return;
+    }
+    throw newResponseError(resp);
+  }
+
+  /// write a file with stream
+  Future<void> wdWriteWithStream(
+    Client self,
+    String path,
+    Stream<List<int>> data,
+    int length, {
+    void Function(int count, int total)? onProgress,
+    CancelToken? cancelToken,
+  }) async {
+    // fix auth error
+    var pResp = await this.wdOptions(self, path, cancelToken: cancelToken);
+    if (pResp.statusCode != 200) {
+      throw newResponseError(pResp);
+    }
+
+    // mkdir
+    await this._createParent(self, path, cancelToken: cancelToken);
+
+    var resp = await this.req(
+      self,
+      'PUT',
+      path,
+      data: data,
+      optionsHandler: (options) => options.headers?['content-length'] = length,
+      onSendProgress: onProgress,
+      cancelToken: cancelToken,
+    );
+    var status = resp.statusCode;
+    if (status == 200 || status == 201 || status == 204) {
+      return;
+    }
+    throw newResponseError(resp);
+  }
+}

--- a/plugins/webdav_client_fork/lib/src/xml.dart
+++ b/plugins/webdav_client_fork/lib/src/xml.dart
@@ -1,0 +1,118 @@
+import 'package:xml/xml.dart';
+
+import 'file.dart';
+import 'utils.dart';
+
+const fileXmlStr = '''<d:propfind xmlns:d='DAV:'>
+			<d:prop>
+				<d:displayname/>
+				<d:resourcetype/>
+				<d:getcontentlength/>
+				<d:getcontenttype/>
+				<d:getetag/>
+				<d:getlastmodified/>
+			</d:prop>
+		</d:propfind>''';
+
+// const quotaXmlStr = '''<d:propfind xmlns:d="DAV:">
+//            <d:prop>
+//              <d:quota-available-bytes/>
+//              <d:quota-used-bytes/>
+//            </d:prop>
+//          </d:propfind>''';
+
+class WebdavXml {
+  static List<XmlElement> findAllElements(XmlDocument document, String tag) =>
+      document.findAllElements(tag, namespace: '*').toList();
+
+  static List<XmlElement> findElements(XmlElement element, String tag) =>
+      element.findElements(tag, namespace: '*').toList();
+
+  static List<File> toFiles(String path, String xmlStr, {skipSelf = true}) {
+    var files = <File>[];
+    var xmlDocument = XmlDocument.parse(xmlStr);
+    List<XmlElement> list = findAllElements(xmlDocument, 'response');
+    // response
+    list.forEach((element) {
+      // name
+      final hrefElements = findElements(element, 'href');
+      String href = hrefElements.isNotEmpty ? hrefElements.single.text : '';
+
+      // propstats
+      var props = findElements(element, 'propstat');
+      // propstat
+      for (var propstat in props) {
+        // ignore != 200
+        if (findElements(propstat, 'status').single.text.contains('200')) {
+          // prop
+          for (var prop in findElements(propstat, 'prop')) {
+            final resourceTypeElements = findElements(prop, 'resourcetype');
+            // isDir
+            bool isDir = resourceTypeElements.isNotEmpty
+                ? findElements(resourceTypeElements.single, 'collection')
+                    .isNotEmpty
+                : false;
+
+            // skip self
+            if (skipSelf) {
+              skipSelf = false;
+              if (isDir) {
+                break;
+              }
+              throw newXmlError('xml parse error(405)');
+            }
+
+            // mimeType
+            final mimeTypeElements = findElements(prop, 'getcontenttype');
+            String mimeType =
+                mimeTypeElements.isNotEmpty ? mimeTypeElements.single.text : '';
+
+            // size
+            int size = 0;
+            if (!isDir) {
+              final sizeElements = findElements(prop, 'getcontentlength');
+              size = sizeElements.isNotEmpty
+                  ? int.parse(sizeElements.single.text)
+                  : 0;
+            }
+
+            // eTag
+            final eTagElements = findElements(prop, 'getetag');
+            String eTag =
+                eTagElements.isNotEmpty ? eTagElements.single.text : '';
+
+            // create time
+            final cTimeElements = findElements(prop, 'creationdate');
+            DateTime? cTime = cTimeElements.isNotEmpty
+                ? DateTime.parse(cTimeElements.single.text).toLocal()
+                : null;
+
+            // modified time
+            final mTimeElements = findElements(prop, 'getlastmodified');
+            DateTime? mTime = mTimeElements.isNotEmpty
+                ? str2LocalTime(mTimeElements.single.text)
+                : null;
+
+            //
+            var str = Uri.decodeFull(href);
+            var name = path2Name(str);
+            var filePath = path + name + (isDir ? '/' : '');
+
+            files.add(File(
+              path: filePath,
+              isDir: isDir,
+              name: name,
+              mimeType: mimeType,
+              size: size,
+              eTag: eTag,
+              cTime: cTime,
+              mTime: mTime,
+            ));
+            break;
+          }
+        }
+      }
+    });
+    return files;
+  }
+}

--- a/plugins/webdav_client_fork/lib/webdav_client.dart
+++ b/plugins/webdav_client_fork/lib/webdav_client.dart
@@ -1,0 +1,6 @@
+library webdav_client;
+
+export 'src/auth.dart';
+export 'src/client.dart';
+export 'src/file.dart';
+export 'src/webdav_dio.dart';

--- a/plugins/webdav_client_fork/pubspec.yaml
+++ b/plugins/webdav_client_fork/pubspec.yaml
@@ -1,0 +1,17 @@
+name: webdav_client
+description: Vendored webdav_client v1.2.2 with a dio 5.x compatibility fix for restore/read2File.
+publish_to: 'none'
+
+version: 1.2.2
+homepage: https://github.com/flymzero/webdav_client
+
+environment:
+  sdk: '>=2.12.0 <4.0.0'
+
+dependencies:
+  dio: ^5.1.0
+  xml: ^6.2.2
+  convert: ^3.1.1
+
+dev_dependencies:
+  test: '>=1.0.0 <2.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,8 @@ dependencies:
   image_picker: ^1.2.0
   ffi: ^2.1.4
 
-  webdav_client: ^1.2.2
+  webdav_client:
+    path: plugins/webdav_client_fork
   dio: ^5.8.0+1
   win32: ^6.0.1
   re_editor: ^0.10.0


### PR DESCRIPTION
### What this fixes

WebDAV **restore** crashes on all platforms (Windows / Android) right after a successful backup:

```
type '_Map<String, dynamic>' is not a subtype of type 'ResponseBody?' of 'value'
  #0 Response.data= (package:dio/src/response.dart:30)
  #1 WdDio.wdReadWithStream (package:webdav_client/src/webdav_dio.dart:318)
```

### Root cause

This is not a bug in FlClash's business code — it is a type-incompatibility between the `webdav_client` dependency (v1.2.2) and **Dio 5.x**.

Restore goes through `webdav_client`'s `read2File()` → `wdReadWithStream()`, which does:

```dart
Response<ResponseBody> resp;
resp = await this.req(   // ← no type argument, so T falls back to `dynamic`
  self, 'GET', path,
  optionsHandler: (o) => o.responseType = ResponseType.stream,
  ...
);
```

`req<T>` is called without an explicit type, so `T` resolves to `dynamic` and propagates into Dio's `requestUri<T>`. In today's Dio 5.x, `fetch<T>` then resets `RequestOptions.responseType` to `ResponseType.json` — so the response body is decoded into a `Map<String, dynamic>`, while `wdReadWithStream` declares the variable as `Response<ResponseBody>`. Dio 5.x's `assureResponse<T>` finally performs the covariant cast `response.data as T?` (`T = ResponseBody`), which throws the reported error.

Backup succeeds because it uses **PUT** (`wdWriteWithStream`), whose `resp` is a non-generic `Response` and never hits the `ResponseBody` covariance assertion. So all three clients share the *same* single dependency bug — not three separate ones.

### Fix

`webdav_client` upstream (1.2.2) is unmaintained with no newer release, so this PR vendors it the way the repo already vendors other plugins (`plugins/proxy`, `plugins/window_ext`, ...):

- **`plugins/webdav_client_fork/`** — a copy of `webdav_client` 1.2.2 with a one-line change in `lib/src/webdav_dio.dart`:
  ```dart
  resp = await this.req<ResponseBody>(   // explicit type argument
  ```
  Passing the explicit generic keeps `responseType: stream` (no JSON fallback), so the `ResponseBody` covariance cast no longer fails.
- **`pubspec.yaml`** — `webdav_client` now points at the local fork via `path:`.

The only functional change is the added generic type argument; everything else in the vendored package is byte-for-byte the upstream 1.2.2 source.

### Testing

The only code change is the added generic type argument (verified against dio's `fetch<T>`/`assureResponse<T>` source). I could not run `flutter analyze`/`flutter test` in this environment (no Flutter SDK available), so a CI re-run on this branch would be valuable before merge.
