### PR TITLE
Fix quick settings tile collapsing the notification panel

### DIFF
--- a/android/app/src/main/kotlin/com/follow/clash/ServiceState.kt
+++ b/android/app/src/main/kotlin/com/follow/clash/ServiceState.kt
@@ -74,6 +74,16 @@ object ServiceState {
         }
     }
 
+    fun toggleRequiresVpnConsent(): Boolean {
+        if (isRunningRequested()) {
+            return false
+        }
+        val options = sharedState.vpnOptions
+            ?: GlobalState.application.sharedState.vpnOptions
+            ?: return false
+        return options.enable && VpnService.prepare(GlobalState.application) != null
+    }
+
     suspend fun refresh(): Long = transitionLock.withLock {
         val current = runTimeMillis
         mutableRunState.value = if (current == 0L) RunState.STOPPED else RunState.STARTED

--- a/android/app/src/main/kotlin/com/follow/clash/TileService.kt
+++ b/android/app/src/main/kotlin/com/follow/clash/TileService.kt
@@ -3,6 +3,7 @@ package com.follow.clash
 import android.annotation.SuppressLint
 import android.os.Build
 import android.service.quicksettings.Tile
+import com.follow.clash.common.GlobalState
 import com.follow.clash.common.QuickAction
 import com.follow.clash.common.quickIntent
 import com.follow.clash.common.toPendingIntent
@@ -28,7 +29,11 @@ class TileService : android.service.quicksettings.TileService() {
 
     override fun onClick() {
         super.onClick()
-        openQuickAction()
+        if (ServiceState.toggleRequiresVpnConsent()) {
+            openQuickAction()
+        } else {
+            GlobalState.launch { ServiceState.handleToggleAction() }
+        }
     }
 
     override fun onStopListening() {

--- a/plugins/setup/buildkit/build_tool/lib/src/go_builder.dart
+++ b/plugins/setup/buildkit/build_tool/lib/src/go_builder.dart
@@ -27,7 +27,10 @@ String _resolveCc(Target target) {
   if (entries.isEmpty) {
     throw BuildException('No NDK prebuilt toolchain found in $prebuiltDir');
   }
-  return p.join(entries.first.path, 'bin', target.ndkCcName);
+  final ccName = Platform.isWindows
+      ? '${target.ndkCcName}.cmd'
+      : target.ndkCcName;
+  return p.join(entries.first.path, 'bin', ccName);
 }
 
 class GoBuilder {


### PR DESCRIPTION
Fixes #2112

### 问题

在快捷设置里点击 FlClash 磁贴，通知面板会立刻收起。声明了 `TOGGLEABLE_TILE=true` 的磁贴本应像 WLAN/蓝牙那样原地切换。

### 原因

`TileService.onClick()` 无条件调用 `startActivityAndCollapse()` 启动透明的 `QuickActionActivity`，而这个 API 的语义就是"启动 Activity 并收起面板"。该 Activity 只是个壳：`onCreate` 调一次 `ServiceState.handleToggleAction()` 就 `finish()`。

启动前台服务并不需要它——系统在磁贴点击时会给 15 秒临时白名单。修复**前**的 logcat：

```
Background started FGS: Allowed [callingPackage: com.follow.clash; ...
  tempAllowListReason:<tile onclick,reasonCode:(unknown:329),duration:15000,callingUid:10280>]
```

即 FGS 本来就不是靠那个 Activity 放行的。唯一真正需要 Activity 的场合是系统 VPN 授权对话框（`VpnService.prepare()` 非 null），故仅在该情况下保留原路径。

### 改动

- `TileService.onClick()`：仅当需要 VPN 授权时走 `QuickActionActivity`，否则直接 `ServiceState.handleToggleAction()`
- 新增 `ServiceState.toggleRequiresVpnConsent()`：停止路径永不需要 UI；启动路径只在"启用 VPN 且系统尚未授权"时需要

磁贴意图仍然只经 `ServiceState` 表达，`ServiceController` 仍是唯一的绑定/运行时所有者。

### 真机验证

Pixel 9 Pro / Android 17，debug 包，同一配置做 A/B：

| 场景 | 改前 | 改后 |
|---|---|---|
| 冷启动点磁贴 | 面板收起、回桌面 | 面板保持展开，磁贴激活，tun0 建立，Activity 启动 0 次 |
| 再点一次停止 | 面板收起 | 面板保持展开，磁贴回未激活，tun0 消失 |
| 应用在后台（Dart 路径） | 面板收起 | 面板保持展开，VPN 正常启动，Activity 启动 0 次 |
| `appops ACTIVATE_VPN deny` | 走 Activity | 仍走 Activity（回退分支生效） |

`flutter analyze --no-fatal-infos` 无问题；`build_tool` 包 `dart analyze` + `dart test` 全绿。

### 第二个 commit（与本修复无关，可单独 drop）

`Fix Go core build on Windows hosts`：Windows 主机上 `make core-android` 一直失败于 `ProcessException: %1 不是有效的 Win32 应用程序`。NDK 的 `aarch64-linux-android21-clang` 无扩展名文件是 bash 脚本，Windows 需要旁边的 `.cmd` 包装器。

旧 `setup.dart` 只把它作为 `CC` 交给 `go build`，Go 的 `exec.LookPath` 会自动补 PATHEXT 所以没暴露；新 buildkit 在算指纹时用 `Process.runSync(cc, ['--version'])` 直接 spawn，Dart 不补 PATHEXT，于是在 `go build` 之前就硬失败。CI 的 `platform: android` 只在 `ubuntu-latest` 上构建，故无覆盖。
