### PR TITLE
[Security] Treat restored scripts as untrusted

### DIFF
--- a/lib/common/migration.dart
+++ b/lib/common/migration.dart
@@ -44,6 +44,7 @@ class _AppMigrationStore implements MigrationStore {
       data.rules,
       data.links,
       data.proxyGroups,
+      restoreScripts: true,
     );
   }
 

--- a/lib/common/task.dart
+++ b/lib/common/task.dart
@@ -331,18 +331,19 @@ Future<String> _encodeLogsTask(List<Log> data) async {
 
 Future<MigrationData> oldToNowTask(Map<String, Object?> data) async {
   final homeDir = await appPath.homeDirPath;
-  return compute<VM3<Map<String, Object?>, String, String>, MigrationData>(
-    _oldToNowTask,
-    VM3(data, homeDir, homeDir),
-  );
+  return compute<
+    VM4<Map<String, Object?>, String, String, bool>,
+    MigrationData
+  >(_oldToNowTask, VM4(data, homeDir, homeDir, true));
 }
 
 Future<MigrationData> _oldToNowTask(
-  VM3<Map<String, Object?>, String, String> data,
+  VM4<Map<String, Object?>, String, String, bool> data,
 ) async {
   final configMap = data.a;
   final sourcePath = data.b;
   final targetPath = data.c;
+  final restoreScripts = data.d;
 
   final accessControlMap = configMap['accessControl'];
   final isAccessControl = configMap['isAccessControl'];
@@ -364,8 +365,10 @@ Future<MigrationData> _oldToNowTask(
   configMap['appSettingProps'] = appSettingProps;
   configMap['proxiesStyleProps'] = configMap['proxiesStyle'];
   configMap['proxiesStyleProps'] = configMap['proxiesStyle'];
-  List rawScripts = configMap['scripts'] as List<dynamic>? ?? [];
-  if (rawScripts.isEmpty) {
+  List rawScripts = restoreScripts
+      ? configMap['scripts'] as List<dynamic>? ?? []
+      : [];
+  if (restoreScripts && rawScripts.isEmpty) {
     final scriptPropsJson = configMap['scriptProps'] as Map<String, dynamic>?;
     if (scriptPropsJson != null) {
       rawScripts = scriptPropsJson['scripts'] as List<dynamic>? ?? [];
@@ -441,11 +444,16 @@ Future<MigrationData> _oldToNowTask(
         }
       }
       final scriptOverwrite = overwrite['scriptOverwrite'] as Map?;
-      if (scriptOverwrite != null) {
+      if (restoreScripts && scriptOverwrite != null) {
         final scriptId = scriptOverwrite['scriptId'] as String?;
         rawProfile['scriptId'] = scriptId != null ? idMap[scriptId] : null;
       }
       rawProfile['overwriteType'] = overwrite['type'];
+    }
+    if (!restoreScripts &&
+        rawProfile['overwriteType'] == OverwriteType.script.name) {
+      rawProfile['overwriteType'] = OverwriteType.standard.name;
+      rawProfile['scriptId'] = null;
     }
 
     final sourceFile = File(_getProfilePath(sourcePath, rawId));
@@ -464,6 +472,18 @@ Future<MigrationData> _oldToNowTask(
     scripts: scripts,
     links: links,
   );
+}
+
+List<Profile> sanitizeRestoredProfiles(Iterable<Profile> profiles) {
+  return profiles.map((profile) {
+    if (profile.overwriteType != OverwriteType.script) {
+      return profile;
+    }
+    return profile.copyWith(
+      overwriteType: OverwriteType.standard,
+      scriptId: null,
+    );
+  }).toList();
 }
 
 Future<String> backupTask(
@@ -545,7 +565,10 @@ Future<MigrationData> _restoreTask(RootIsolateToken token) async {
   final dir = Directory(restoreDirPath);
   await dir.create(recursive: true);
   for (final file in archive.files) {
-    final outPath = join(restoreDirPath, posix.normalize(file.name));
+    final outPath = restoreEntryPath(restoreDirPath, file.name);
+    if (outPath == null) {
+      continue;
+    }
     final outputStream = OutputFileStream(outPath);
     file.writeContent(outputStream);
     await outputStream.close();
@@ -562,7 +585,7 @@ Future<MigrationData> _restoreTask(RootIsolateToken token) async {
   MigrationData migrationData = MigrationData(configMap: restoreConfigMap);
   if (version == 0 && restoreConfigMap != null) {
     migrationData = await _oldToNowTask(
-      VM3(restoreConfigMap, restoreDirPath, homeDirPath),
+      VM4(restoreConfigMap, restoreDirPath, homeDirPath, false),
     );
     return migrationData;
   }
@@ -580,35 +603,44 @@ Future<MigrationData> _restoreTask(RootIsolateToken token) async {
   );
   final results = await Future.wait([
     database.profilesDao.query().get(),
-    database.scriptsDao.query().get(),
     database.rules.all().map((item) => item.toRule()).get(),
     database.profileRuleLinks.all().map((item) => item.toLink()).get(),
     database.proxyGroups.all().map((item) => item.toProxyGroup()).get(),
   ]);
   final profiles = results[0].cast<Profile>();
-  final scripts = results[1].cast<Script>();
   final profilesMigration = profiles.map(
     (item) => VM2(
       _getProfilePath(restoreDirPath, item.id.toString()),
       _getProfilePath(homeDirPath, item.id.toString()),
     ),
   );
-  final scriptsMigration = scripts.map(
-    (item) => VM2(
-      _getScriptPath(restoreDirPath, item.id.toString()),
-      _getScriptPath(homeDirPath, item.id.toString()),
-    ),
-  );
-  await _copyWithMapList([...profilesMigration, ...scriptsMigration]);
+  final safeProfiles = sanitizeRestoredProfiles(profiles);
+  await _copyWithMapList(profilesMigration.toList());
   migrationData = migrationData.copyWith(
-    profiles: profiles,
-    scripts: scripts,
-    rules: results[2].cast<Rule>(),
-    links: results[3].cast<ProfileRuleLink>(),
-    proxyGroups: results[4].cast<ProxyGroup>(),
+    profiles: safeProfiles,
+    scripts: const [],
+    rules: results[1].cast<Rule>(),
+    links: results[2].cast<ProfileRuleLink>(),
+    proxyGroups: results[3].cast<ProxyGroup>(),
   );
   await database.close();
   return migrationData;
+}
+
+@visibleForTesting
+String? restoreEntryPath(String restoreDirPath, String name) {
+  final normalized = posix.normalize(name.replaceAll('\\', '/'));
+  if (normalized.isEmpty ||
+      posix.isAbsolute(normalized) ||
+      normalized == '..' ||
+      normalized.startsWith('../')) {
+    return null;
+  }
+  final outPath = normalize(join(restoreDirPath, normalized));
+  if (!isWithin(restoreDirPath, outPath)) {
+    return null;
+  }
+  return outPath;
 }
 
 Future<void> _copyWithMapList(List<VM2<String, String>> copyMapList) async {

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -114,6 +114,7 @@ class Database extends _$Database {
     List<ProfileRuleLink> links,
     List<ProxyGroup> proxyGroups, {
     bool isOverride = false,
+    bool restoreScripts = false,
   }) async {
     if (profiles.isNotEmpty ||
         scripts.isNotEmpty ||
@@ -126,7 +127,9 @@ class Database extends _$Database {
                 b,
                 profiles.map((item) => item.toCompanion()),
               );
-        scriptsDao.setAllWithBatch(b, scripts);
+        if (restoreScripts) {
+          scriptsDao.setAllWithBatch(b, scripts);
+        }
         rulesDao.restoreWithBatch(b, rules, links);
         proxyGroupsDao.setAllWithBatch(null, b, proxyGroups);
       });

--- a/lib/providers/actions/backup.dart
+++ b/lib/providers/actions/backup.dart
@@ -36,6 +36,7 @@ class BackupAction extends _$BackupAction {
         migrationData.links,
         migrationData.proxyGroups,
         isOverride: isOverride,
+        restoreScripts: false,
       );
       final configMap = migrationData.configMap;
       if (option == RestoreOption.onlyProfiles || configMap == null) return;

--- a/lib/providers/generated/action.g.dart
+++ b/lib/providers/generated/action.g.dart
@@ -40,7 +40,7 @@ final class CommonActionProvider extends $NotifierProvider<CommonAction, void> {
   }
 }
 
-String _$commonActionHash() => r'81d01cab066e94793cdaa4ff89806ebff6030f50';
+String _$commonActionHash() => r'52a2cd8f01ea3fbbb76b7a7958332bf0b6f04211';
 
 abstract class _$CommonAction extends $Notifier<void> {
   void build();
@@ -91,7 +91,7 @@ final class SetupActionProvider extends $NotifierProvider<SetupAction, void> {
   }
 }
 
-String _$setupActionHash() => r'27018fa3a8606b501472f50aa4b46eeb0c964ff3';
+String _$setupActionHash() => r'5a79357c5d361292f9131c347890356b138fe077';
 
 abstract class _$SetupAction extends $Notifier<void> {
   void build();
@@ -142,7 +142,7 @@ final class BackupActionProvider extends $NotifierProvider<BackupAction, void> {
   }
 }
 
-String _$backupActionHash() => r'3c115d169b912577a3bd87796cefafce3695a019';
+String _$backupActionHash() => r'18142bc7f61931da3529a805ccfbfed9a63291fe';
 
 abstract class _$BackupAction extends $Notifier<void> {
   void build();
@@ -193,7 +193,7 @@ final class CoreActionProvider extends $NotifierProvider<CoreAction, void> {
   }
 }
 
-String _$coreActionHash() => r'f314ae5f40da30a71ece0b5f84cdd2e9d7335ee9';
+String _$coreActionHash() => r'972ad46fcf005c6c6e91f8f11965e142920941aa';
 
 abstract class _$CoreAction extends $Notifier<void> {
   void build();
@@ -398,7 +398,7 @@ final class ProxiesActionProvider
   }
 }
 
-String _$proxiesActionHash() => r'1a734ab542f5e3734f9887768567e1eb14e0decf';
+String _$proxiesActionHash() => r'c3125fbd8c342d859ebb3a82a83e0ea69457c2f3';
 
 abstract class _$ProxiesAction extends $Notifier<void> {
   void build();

--- a/test/common/task_test.dart
+++ b/test/common/task_test.dart
@@ -64,6 +64,38 @@ void main() {
     expect(groups, isEmpty);
   });
 
+  test('sanitizeRestoredProfiles disables script overwrites', () {
+    const scriptProfile = Profile(
+      id: 1,
+      autoUpdateDuration: Duration.zero,
+      overwriteType: OverwriteType.script,
+      scriptId: 42,
+    );
+    const standardProfile = Profile(
+      id: 2,
+      autoUpdateDuration: Duration.zero,
+      overwriteType: OverwriteType.standard,
+    );
+
+    final profiles = sanitizeRestoredProfiles([scriptProfile, standardProfile]);
+
+    expect(profiles[0].overwriteType, OverwriteType.standard);
+    expect(profiles[0].scriptId, isNull);
+    expect(profiles[1], standardProfile);
+  });
+
+  test(
+    'restoreEntryPath confines archive entries to the restore directory',
+    () {
+      expect(restoreEntryPath('/tmp/restore', '../outside.txt'), isNull);
+      expect(restoreEntryPath('/tmp/restore', '/tmp/outside.txt'), isNull);
+      expect(
+        restoreEntryPath('/tmp/restore', r'profiles\1.yaml'),
+        '/tmp/restore/profiles/1.yaml',
+      );
+    },
+  );
+
   test(
     'makeRealProfileTask normalizes runtime config and added rules',
     () async {

--- a/test/database/dao_coverage_test.dart
+++ b/test/database/dao_coverage_test.dart
@@ -70,6 +70,34 @@ void main() {
   );
 
   test(
+    'restore can preserve existing scripts when scripts are untrusted',
+    () async {
+      final existing = Script(
+        id: 1,
+        label: 'Existing',
+        lastUpdateTime: DateTime(2026, 1, 1),
+      );
+      final incoming = Script(
+        id: 2,
+        label: 'Incoming',
+        lastUpdateTime: DateTime(2026, 1, 2),
+      );
+      await database.scriptsDao.setAll([existing]);
+
+      await database.restore(
+        const [],
+        [incoming],
+        const [],
+        const [],
+        const [],
+        restoreScripts: false,
+      );
+
+      expect(await database.scriptsDao.query().get(), [existing]);
+    },
+  );
+
+  test(
     'generated table managers create, filter, order, and update rows',
     () async {
       final date = DateTime.utc(2026, 7, 26);
@@ -414,9 +442,15 @@ void main() {
       proxies: ['DIRECT'],
     );
 
-    await database.restore([profile], [script], [rule], [link], [
-      group,
-    ], isOverride: true);
+    await database.restore(
+      [profile],
+      [script],
+      [rule],
+      [link],
+      [group],
+      isOverride: true,
+      restoreScripts: true,
+    );
     expect(await database.profilesDao.query().get(), [
       profile.copyWith(order: 0),
     ]);


### PR DESCRIPTION
## Problem

The shared restore flow for WebDAV and local backups could import script records and copy script files into active application data. A restored profile could then select and execute the restored overwrite script without a separate trust decision.

## Changes

- Stop importing script records and copying script files into the active scripts directory during archive restoration.
- Restore script overwrite profiles as standard profiles with their script references cleared, including legacy backups.
- Make script restoration opt-in at the database layer, preserving existing locally installed scripts when restoring a backup.
- Keep trusted in-place configuration migration explicitly opted in to script migration.
- Skip archive entries whose normalized paths are absolute or escape the restore directory.
- Add regression tests for profile sanitization, archive path containment, and preservation of existing scripts, and regenerate provider metadata.

## Compatibility and scope

Normal profile, rule, proxy-group, and configuration restoration remains supported. Restored script overwrite profiles require manual review and reassociation with a trusted script. Existing local scripts are not removed or overwritten by archive restoration.

This change applies to both local and WebDAV backups. It does not add backup authentication or change the JavaScript runtime.

## Validation

Validated on Linux with Flutter 3.44.4 and Dart 3.12.2:

- `flutter pub get`: passed.
- `flutter analyze --no-fatal-infos`: no issues found.
- `flutter test --reporter expanded`: 725 tests passed.
- Focused task/database tests after code generation: 16 tests passed.
- `dart run build_runner build --delete-conflicting-outputs`: completed; the tool reported that the obsolete flag was ignored.
- `git diff --check`: passed.

Validation covers source analysis and automated Flutter tests; a packaged application build and a fresh end-to-end exploit run were not performed. No exploit archive, credentials, or network-exfiltration payload is included in this PR.
