### PR TITLE
Build RPM packages for Linux arm64

### DIFF
--- a/setup.dart
+++ b/setup.dart
@@ -6,7 +6,7 @@ import 'package:path/path.dart' as p;
 
 const _allTargets = <String, String>{
   'android': 'apk',
-  'linux': 'deb', // appimage + rpm added for amd64 only
+  'linux': 'deb',
   'macos': 'dmg',
   'windows': 'exe,zip',
 };
@@ -117,7 +117,9 @@ Map<String, String> createBuildEnvironment(String env) {
 
 String _getTargets(String platform, String arch, String? customTargets) {
   if (customTargets != null) return customTargets;
-  if (platform == 'linux' && arch == 'amd64') return 'deb,appimage,rpm';
+  if (platform == 'linux') {
+    return arch == 'amd64' ? 'deb,appimage,rpm' : 'deb,rpm';
+  }
   return _allTargets[platform]!;
 }
 
@@ -252,12 +254,10 @@ Future<int> _ensureLinuxDependencies(String arch) async {
     ['libkeybinder-3.0-dev'],
     ['libsecret-1-dev'],
     ['locate'],
+    ['rpm', 'patchelf'],
   ];
   if (arch == 'amd64') {
-    pkgGroups.addAll([
-      ['rpm', 'patchelf'],
-      ['libfuse2'],
-    ]);
+    pkgGroups.add(['libfuse2']);
   }
 
   final missingGroups = <List<String>>[];


### PR DESCRIPTION
## Problem

Linux arm64 releases only ship a `.deb`, while amd64 ships `.deb`, `.rpm` and `.AppImage`. Users on aarch64 Fedora / RHEL / openSUSE have to convert the deb by hand.

Current arm64 assets for `v0.8.96`:

```
FlClash-0.8.96-linux-arm64.deb
```

## Cause

`setup.dart` hardcodes the extra Linux targets to amd64:

```dart
if (platform == 'linux' && arch == 'amd64') return 'deb,appimage,rpm';
...
if (arch == 'amd64') {
  pkgGroups.addAll([
    ['rpm', 'patchelf'],
    ['libfuse2'],
  ]);
}
```

The RPM maker itself is already architecture-aware: `MakeRPMConfig` defaults `BuildArch` to `uname -m` (i.e. `aarch64` on arm64), and the CI already builds Linux arm64 on `ubuntu-24.04-arm`.

## Change

- enable the `rpm` target for Linux arm64
- install `rpm` + `patchelf` on arm64 as well (needed by the RPM maker)
- keep `libfuse2` / `appimagetool` amd64-only, so AppImage output is unchanged

## Result

The existing `linux` / `arm64` CI job will also produce `FlClash-<version>-linux-arm64.rpm` next to the deb. No workflow change is required.

## Notes

- I could not run the full aarch64 Linux packaging locally, so this relies on the existing `ubuntu-24.04-arm` job to produce and validate the artifact.
- AppImage for arm64 can be enabled separately if wanted; `appimagetool` already publishes an aarch64 build.
