### PR TITLE
[Security] Validate profile redirect targets

### DIFF
--- a/lib/common/request.dart
+++ b/lib/common/request.dart
@@ -10,8 +10,12 @@ import 'package:fl_clash/models/models.dart';
 import 'package:fl_clash/state.dart';
 
 class Request {
+  static const _redirectStatusCodes = {301, 302, 303, 307, 308};
+  static const _maxRedirects = 5;
+
   late final Dio dio;
   late final Dio _clashDio;
+  final Future<List<InternetAddress>> Function(String host) _resolveHost;
   String? userAgent;
 
   ProviderReader? _read;
@@ -20,9 +24,13 @@ class Request {
     _read = read;
   }
 
-  Request() {
+  Request({
+    Dio? clashDio,
+    Future<List<InternetAddress>> Function(String host)? resolveHost,
+  }) : _resolveHost = resolveHost ?? ((host) => InternetAddress.lookup(host)) {
     dio = Dio(BaseOptions(headers: {'User-Agent': browserUa}));
-    _clashDio = Dio();
+    _clashDio = clashDio ?? Dio();
+    if (clashDio != null) return;
     _clashDio.httpClientAdapter = IOHttpClientAdapter(
       createHttpClient: () {
         final client = HttpClient();
@@ -41,10 +49,7 @@ class Request {
 
   Future<Response<Uint8List>> getFileResponseForUrl(String url) async {
     try {
-      return await _clashDio.get<Uint8List>(
-        url,
-        options: Options(responseType: ResponseType.bytes),
-      );
+      return await _getResponseForUrl<Uint8List>(url, ResponseType.bytes);
     } catch (e) {
       commonPrint.log(
         'getFileResponseForUrl error ${compactError(e)}',
@@ -56,10 +61,7 @@ class Request {
 
   Future<Response<String>> getTextResponseForUrl(String url) async {
     try {
-      return await _clashDio.get<String>(
-        url,
-        options: Options(responseType: ResponseType.plain),
-      );
+      return await _getResponseForUrl<String>(url, ResponseType.plain);
     } catch (e) {
       commonPrint.log(
         'getTextResponseForUrl error ${compactError(e)}',
@@ -67,6 +69,117 @@ class Request {
       );
       rethrow;
     }
+  }
+
+  Future<Response<T>> _getResponseForUrl<T>(
+    String url,
+    ResponseType responseType,
+  ) async {
+    var uri = Uri.parse(url);
+    for (var redirects = 0; ; redirects++) {
+      final response = await _clashDio.getUri<T>(
+        uri,
+        options: Options(
+          responseType: responseType,
+          followRedirects: false,
+          maxRedirects: 0,
+          validateStatus: (status) =>
+              status != null &&
+              ((status >= 200 && status < 300) ||
+                  _redirectStatusCodes.contains(status)),
+        ),
+      );
+      if (!_redirectStatusCodes.contains(response.statusCode)) {
+        return response;
+      }
+      final target = _redirectTarget(uri, response);
+      if (target == null || redirects >= _maxRedirects) {
+        throw _redirectException(response);
+      }
+      await _validateRedirectTarget(target, response);
+      uri = target;
+    }
+  }
+
+  Uri? _redirectTarget(Uri uri, Response<dynamic> response) {
+    final location = response.headers.value('location');
+    if (location == null || location.isEmpty) return null;
+    final target = Uri.tryParse(location);
+    return target == null ? null : uri.resolveUri(target);
+  }
+
+  Future<void> _validateRedirectTarget(
+    Uri target,
+    Response<dynamic> response,
+  ) async {
+    if ((target.scheme != 'http' && target.scheme != 'https') ||
+        target.host.isEmpty) {
+      throw _redirectException(response);
+    }
+    final literal = InternetAddress.tryParse(target.host);
+    if (literal != null) {
+      if (_isLocalAddress(literal)) throw _redirectException(response);
+      return;
+    }
+    final host = target.host.toLowerCase();
+    if (host == 'localhost' || host.endsWith('.localhost')) {
+      throw _redirectException(response);
+    }
+    final List<InternetAddress> addresses;
+    try {
+      addresses = await _resolveHost(target.host);
+    } catch (_) {
+      throw _redirectException(response);
+    }
+    if (addresses.isEmpty ||
+        addresses.any(
+          (address) => _isLocalAddress(address, allowFakeIp: true),
+        )) {
+      throw _redirectException(response);
+    }
+  }
+
+  bool _isLocalAddress(InternetAddress address, {bool allowFakeIp = false}) {
+    final bytes = address.rawAddress;
+    if (address.type == InternetAddressType.IPv4) {
+      return bytes[0] == 0 ||
+          bytes[0] == 10 ||
+          bytes[0] == 127 ||
+          (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) ||
+          (bytes[0] == 169 && bytes[1] == 254) ||
+          (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) ||
+          (bytes[0] == 192 && bytes[1] == 168) ||
+          (!allowFakeIp &&
+              bytes[0] == 198 &&
+              bytes[1] >= 18 &&
+              bytes[1] <= 19) ||
+          bytes[0] >= 224;
+    }
+    final isUnspecified = bytes.every((byte) => byte == 0);
+    final isUniqueLocal = bytes[0] & 0xfe == 0xfc;
+    final isLinkLocal = bytes[0] == 0xfe && bytes[1] & 0xc0 == 0x80;
+    final isMulticast = bytes[0] == 0xff;
+    final isIPv4Mapped =
+        bytes.take(10).every((byte) => byte == 0) &&
+        bytes[10] == 0xff &&
+        bytes[11] == 0xff;
+    if (isIPv4Mapped) {
+      return _isLocalAddress(InternetAddress.fromRawAddress(bytes.sublist(12)));
+    }
+    return address.isLoopback ||
+        isUnspecified ||
+        isUniqueLocal ||
+        isLinkLocal ||
+        isMulticast;
+  }
+
+  DioException _redirectException(Response<dynamic> response) {
+    return DioException(
+      requestOptions: response.requestOptions,
+      response: response,
+      type: DioExceptionType.badResponse,
+      message: 'Profile redirect target is not allowed',
+    );
   }
 
   Future<Map<String, dynamic>?> checkForUpdate() async {

--- a/test/common/request_test.dart
+++ b/test/common/request_test.dart
@@ -1,6 +1,38 @@
+import 'dart:io';
+import 'dart:typed_data';
+
 import 'package:dio/dio.dart';
 import 'package:fl_clash/common/request.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+class _ScriptedAdapter implements HttpClientAdapter {
+  _ScriptedAdapter(this._response);
+
+  final ResponseBody Function(RequestOptions options, int requestNumber)
+  _response;
+  final List<RequestOptions> requests = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+    return _response(options, requests.length);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Request _requestWith(
+  _ScriptedAdapter adapter, {
+  Future<List<InternetAddress>> Function(String host)? resolveHost,
+}) {
+  final dio = Dio()..httpClientAdapter = adapter;
+  return Request(clashDio: dio, resolveHost: resolveHost);
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -31,5 +63,232 @@ void main() {
         ),
       ),
     );
+  });
+
+  test('follows a redirect whose host resolves publicly', () async {
+    final adapter = _ScriptedAdapter((options, requestNumber) {
+      if (requestNumber == 1) {
+        return ResponseBody.fromString(
+          '',
+          HttpStatus.found,
+          headers: {
+            'location': ['https://cdn.example/profile'],
+          },
+        );
+      }
+      return ResponseBody.fromString('profile', HttpStatus.ok);
+    });
+    final client = _requestWith(
+      adapter,
+      resolveHost: (_) async => [InternetAddress('93.184.216.34')],
+    );
+
+    final response = await client.getTextResponseForUrl(
+      'https://origin.example/profile',
+    );
+
+    expect(response.data, 'profile');
+    expect(adapter.requests, hasLength(2));
+    expect(adapter.requests.last.uri, Uri.parse('https://cdn.example/profile'));
+  });
+
+  test('resolves a relative redirect before validating it', () async {
+    final adapter = _ScriptedAdapter((options, requestNumber) {
+      if (requestNumber == 1) {
+        return ResponseBody.fromString(
+          '',
+          HttpStatus.temporaryRedirect,
+          headers: {
+            'location': ['/moved'],
+          },
+        );
+      }
+      return ResponseBody.fromString('profile', HttpStatus.ok);
+    });
+    final client = _requestWith(
+      adapter,
+      resolveHost: (_) async => [InternetAddress('93.184.216.34')],
+    );
+
+    await client.getTextResponseForUrl('https://origin.example/profile');
+
+    expect(
+      adapter.requests.last.uri,
+      Uri.parse('https://origin.example/moved'),
+    );
+  });
+
+  test('rejects redirect targets on local networks', () async {
+    final targets = [
+      'http://127.0.0.1:47890/logs',
+      'http://10.0.0.1/',
+      'http://169.254.169.254/',
+      'http://192.168.1.1/',
+      'http://198.18.0.1/',
+      'http://localhost/',
+      'http://service.localhost/',
+      'http://[::1]/',
+      'http://[fd00::1]/',
+      'http://[fe80::1]/',
+      'http://[::ffff:127.0.0.1]/',
+      'http://2130706433/',
+    ];
+
+    for (final target in targets) {
+      final adapter = _ScriptedAdapter((options, requestNumber) {
+        return ResponseBody.fromString(
+          '',
+          HttpStatus.found,
+          headers: {
+            'location': [target],
+          },
+        );
+      });
+      final client = _requestWith(
+        adapter,
+        resolveHost: (_) async => [InternetAddress.loopbackIPv4],
+      );
+
+      await expectLater(
+        client.getTextResponseForUrl('https://origin.example/profile'),
+        throwsA(
+          isA<DioException>()
+              .having(
+                (error) => error.type,
+                'type',
+                DioExceptionType.badResponse,
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                'Profile redirect target is not allowed',
+              ),
+        ),
+        reason: target,
+      );
+      expect(adapter.requests, hasLength(1), reason: target);
+    }
+  });
+
+  test('rejects a hostname when any resolved address is private', () async {
+    final adapter = _ScriptedAdapter((options, requestNumber) {
+      return ResponseBody.fromString(
+        '',
+        HttpStatus.found,
+        headers: {
+          'location': ['https://internal.example/profile'],
+        },
+      );
+    });
+    final client = _requestWith(
+      adapter,
+      resolveHost: (_) async => [
+        InternetAddress('93.184.216.34'),
+        InternetAddress('10.0.0.1'),
+      ],
+    );
+
+    await expectLater(
+      client.getTextResponseForUrl('https://origin.example/profile'),
+      throwsA(isA<DioException>()),
+    );
+
+    expect(adapter.requests, hasLength(1));
+  });
+
+  test('allows a public hostname resolved through Clash fake IP DNS', () async {
+    final adapter = _ScriptedAdapter((options, requestNumber) {
+      if (requestNumber == 1) {
+        return ResponseBody.fromString(
+          '',
+          HttpStatus.found,
+          headers: {
+            'location': ['https://cdn.example/profile'],
+          },
+        );
+      }
+      return ResponseBody.fromString('profile', HttpStatus.ok);
+    });
+    final client = _requestWith(
+      adapter,
+      resolveHost: (_) async => [InternetAddress('198.18.0.1')],
+    );
+
+    final response = await client.getTextResponseForUrl(
+      'https://origin.example/profile',
+    );
+
+    expect(response.data, 'profile');
+    expect(adapter.requests, hasLength(2));
+  });
+
+  test('rejects a redirect target that cannot be resolved', () async {
+    final adapter = _ScriptedAdapter((options, requestNumber) {
+      return ResponseBody.fromString(
+        '',
+        HttpStatus.found,
+        headers: {
+          'location': ['https://missing.example/profile'],
+        },
+      );
+    });
+    final client = _requestWith(
+      adapter,
+      resolveHost: (_) => throw const SocketException('lookup failed'),
+    );
+
+    await expectLater(
+      client.getTextResponseForUrl('https://origin.example/profile'),
+      throwsA(isA<DioException>()),
+    );
+
+    expect(adapter.requests, hasLength(1));
+  });
+
+  test('rejects redirects without a usable HTTP location', () async {
+    final locations = <String?>[null, '', 'file:///tmp/profile'];
+
+    for (final location in locations) {
+      final adapter = _ScriptedAdapter((options, requestNumber) {
+        return ResponseBody.fromString(
+          '',
+          HttpStatus.found,
+          headers: {
+            if (location != null) 'location': [location],
+          },
+        );
+      });
+      final client = _requestWith(adapter);
+
+      await expectLater(
+        client.getTextResponseForUrl('https://origin.example/profile'),
+        throwsA(isA<DioException>()),
+        reason: '$location',
+      );
+      expect(adapter.requests, hasLength(1), reason: '$location');
+    }
+  });
+
+  test('stops after five redirects', () async {
+    final adapter = _ScriptedAdapter((options, requestNumber) {
+      return ResponseBody.fromString(
+        '',
+        HttpStatus.found,
+        headers: {
+          'location': ['https://public.example/$requestNumber'],
+        },
+      );
+    });
+    final client = _requestWith(
+      adapter,
+      resolveHost: (_) async => [InternetAddress('93.184.216.34')],
+    );
+
+    await expectLater(
+      client.getTextResponseForUrl('https://origin.example/profile'),
+      throwsA(isA<DioException>()),
+    );
+
+    expect(adapter.requests, hasLength(6));
   });
 }


### PR DESCRIPTION
## Summary

- follow profile-download redirects explicitly instead of delegating them to `HttpClient`
- reject redirect targets using non-HTTP schemes, loopback, link-local, private, CGNAT, multicast, or other local/special addresses
- resolve hostname targets before following them and reject mixed public/private answers
- retain public and relative redirects, cap the chain at five hops, and preserve Clash Fake-IP DNS compatibility

## Security impact

Profile downloads previously followed redirects automatically. An attacker-controlled subscription endpoint could redirect the download GET to a local-only HTTP service; FlClash explicitly sends loopback traffic directly, so that request bypassed its proxy. The redirect is now rejected before any request is sent to the target.

## Tests

- `flutter test test/common/request_test.dart --reporter expanded` (10 passed)
- `flutter test --reporter expanded --coverage` (1856 passed, 3 skipped)
- `dart run tool/check_coverage.dart coverage/lcov.info 75` (79.40%; every group floor passed)
- `flutter analyze --no-fatal-infos` (passes; one pre-existing `prefer_const_constructors` info in `test/widgets/scrollbar_inset_test.dart`)
- repository formatting, comment-density, and commit-message checks

Native asset hooks were disabled only for the local Dart/Flutter test run because Go is unavailable in the test environment. `pubspec.yaml` was restored before committing; this PR changes no native or generated files.
